### PR TITLE
Background and Foreground of Context Menus and Dialogs regarding colors in colors xml

### DIFF
--- a/1080i/Defaults.xml
+++ b/1080i/Defaults.xml
@@ -18,7 +18,7 @@
         <height>66</height>
         <aligny>center</aligny>
         <font>Small</font>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <focusedcolor>Black70</focusedcolor>
         <selectedcolor>Highlight2</selectedcolor>
         <disabledcolor>Black30</disabledcolor>
@@ -61,7 +61,7 @@
         <aligny>center</aligny>
         <font>Small</font>
         <textoffsetx>30</textoffsetx>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <focusedcolor>White100</focusedcolor>
         <disabledcolor>Black30</disabledcolor>
         <selectedcolor>Highlight2</selectedcolor>
@@ -76,7 +76,7 @@
         <aligny>center</aligny>
         <font>Small</font>
         <textoffsetx>30</textoffsetx>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <focusedcolor>White100</focusedcolor>
         <selectedcolor>Highlight2</selectedcolor>
         <disabledcolor>Black30</disabledcolor>
@@ -96,14 +96,14 @@
         <radiowidth>32</radiowidth>
         <radioheight>32</radioheight>
         <textoffsetx>30</textoffsetx>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <focusedcolor>White100</focusedcolor>
         <disabledcolor>Black30</disabledcolor>
         <selectedcolor>Highlight2</selectedcolor>
         <texturefocus colordiffuse="White12">common/white.png</texturefocus>
         <texturenofocus>noop</texturenofocus>
-        <textureradiofocus colordiffuse="Black70">buttons/radio-on.png</textureradiofocus>
-        <textureradionofocus colordiffuse="Black30">buttons/radio-off.png</textureradionofocus>
+        <textureradiofocus colordiffuse="DialogForeground">buttons/radio-on.png</textureradiofocus>
+        <textureradionofocus colordiffuse="DialogForeground30">buttons/radio-off.png</textureradionofocus>
         <textoffsetx>30</textoffsetx>
         <pulseonselect>false</pulseonselect>
     </default>
@@ -113,14 +113,14 @@
         <font>Small</font>
         <spinwidth>32</spinwidth>
         <spinheight>32</spinheight>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <focusedcolor>White100</focusedcolor>
         <disabledcolor>Black12</disabledcolor>
         <selectedcolor>Highlight2</selectedcolor>
         <texturefocus colordiffuse="White12">common/white.png</texturefocus>
         <texturenofocus>noop</texturenofocus>
-        <textureup flipy="true" colordiffuse="Black30">buttons/spin-down.png</textureup>
-        <texturedown colordiffuse="Black30">buttons/spin-down.png</texturedown>
+        <textureup flipy="true" colordiffuse="DialogForeground30">buttons/spin-down.png</textureup>
+        <texturedown colordiffuse="DialogForeground30">buttons/spin-down.png</texturedown>
         <textureupfocus flipy="true" colordiffuse="White100">buttons/spin-down.png</textureupfocus>
         <texturedownfocus colordiffuse="White100">buttons/spin-down.png</texturedownfocus>
         <textoffsetx>30</textoffsetx>
@@ -141,7 +141,7 @@
         <textureupfocus>other_textures/ArrowUpFo.png</textureupfocus>
         <texturedownfocus>other_textures/ArrowDownFo.png</texturedownfocus>
         <font>Small</font>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <focusedcolor>White100</focusedcolor>
         <disabledcolor>Black12</disabledcolor>
         <textoffsetx>30</textoffsetx>
@@ -181,7 +181,7 @@
         <textureslidernibfocus border="2">other_textures/OSD/SliderNibFO.png</textureslidernibfocus>
         <font>Small</font>
         <aligny>center</aligny>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <focusedcolor>White100</focusedcolor>
         <disabledcolor>Black12</disabledcolor>
         <textoffsetx>30</textoffsetx>
@@ -203,7 +203,7 @@
 
     <default type="textbox">
         <font>Small</font>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <shadowcolor>noop</shadowcolor>
         <selectedcolor>Highlight2</selectedcolor>
         <pagecontrol>61</pagecontrol>

--- a/1080i/DialogAddonSettings.xml
+++ b/1080i/DialogAddonSettings.xml
@@ -18,7 +18,7 @@
                 <posy>-30</posy>
                 <width>1500</width>
                 <height>975</height>
-                <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
             </control>
 
             <control type="label" id="20">

--- a/1080i/DialogAlbumInfo.xml
+++ b/1080i/DialogAlbumInfo.xml
@@ -56,31 +56,31 @@
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar1].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar1].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar2].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar2].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar3].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar3].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar4].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar4].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar5].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar5].png</texture>
                 </control>
                 
                 

--- a/1080i/DialogBusy.xml
+++ b/1080i/DialogBusy.xml
@@ -17,8 +17,8 @@
                 <posx>0</posx>
                 <posy>0</posy>
                 <width>450</width>
-                <height>117</height>
-                <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                <height>110</height>
+                <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
             </control>
 
             <control type="image">
@@ -40,7 +40,7 @@
                 <height>48</height>
                 <align>left</align>
                 <label>$LOCALIZE[20186]...</label>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
             </control>
 
         </control>

--- a/1080i/DialogContentSettings.xml
+++ b/1080i/DialogContentSettings.xml
@@ -50,7 +50,7 @@
                     <aligny>center</aligny>
                     <posy>120</posy>
                     <label>20344</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                 </control>
 
                 <control type="label">
@@ -61,7 +61,7 @@
                     <height>70</height>
                     <aligny>center</aligny>
                     <align>right</align>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                     <label>$INFO[Control.GetLabel(20)]</label>
                 </control>
             </control>
@@ -129,7 +129,7 @@
                     <control type="label">
                         <posx>30</posx>
                         <width>570</width>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <info>ListItem.Label</info>
                         <visible>!Control.HasFocus(21)</visible>
                     </control>

--- a/1080i/DialogFavourites.xml
+++ b/1080i/DialogFavourites.xml
@@ -17,7 +17,7 @@
             <control type="image">
                 <width>1080</width>
                 <height>900</height>
-                <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
             </control>
             
             <control type="label" id="1">
@@ -27,7 +27,7 @@
                 <width>990</width>
                 <align>center</align>
                 <font>MediumBold</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
                 <label>1036</label>
             </control>
 
@@ -58,7 +58,7 @@
                         <width>496</width>
                         <height>135</height>
                         <font>SmallBold</font>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <selectedcolor>Black70</selectedcolor>
                         <info>ListItem.Label</info>
                         <animation effect="slide" end="0,18" condition="IsEmpty(ListItem.Property(Addon.Summary))">Conditional</animation>
@@ -69,7 +69,7 @@
                         <width>496</width>
                         <height>135</height>
                         <font>Mini</font>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <selectedcolor>Black70</selectedcolor>
                         <label>$INFO[ListItem.Property(Addon.Summary)]</label>
                     </control>
@@ -94,8 +94,8 @@
                             <width>496</width>
                             <height>135</height>
                             <font>SmallBold</font>
-                            <textcolor>Black70</textcolor>
-                            <selectedcolor>Black70</selectedcolor>
+                            <textcolor>DialogForeground</textcolor>
+                            <selectedcolor>DialogForeground</selectedcolor>
                             <info>ListItem.Label</info>
                             <animation effect="slide" end="0,18" condition="IsEmpty(ListItem.Label2)">Conditional</animation>
                         </control>
@@ -105,8 +105,8 @@
                             <width>496</width>
                             <height>135</height>
                             <font>Mini</font>
-                            <textcolor>Black70</textcolor>
-                            <selectedcolor>Black70</selectedcolor>
+                            <textcolor>DialogForeground</textcolor>
+                            <selectedcolor>DialogForeground</selectedcolor>
                             <label>$INFO[ListItem.Label2]</label>
                         </control>
                     </control>

--- a/1080i/DialogMediaSource.xml
+++ b/1080i/DialogMediaSource.xml
@@ -39,7 +39,7 @@
                         <left>30</left>
                         <right>30</right>
                         <font>SmallBold</font>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <height>66</height>
                         <aligny>center</aligny>
                         <info>ListItem.Label</info>
@@ -48,7 +48,7 @@
                     <control type="label">
                         <left>30</left>
                         <right>30</right>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <align>right</align>
                         <height>66</height>
                         <aligny>center</aligny>

--- a/1080i/DialogNetworkSetup.xml
+++ b/1080i/DialogNetworkSetup.xml
@@ -40,41 +40,41 @@
                     <align>left</align>
                     <reverse>yes</reverse>
                     <label>1008</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                     <texturefocus colordiffuse="Highlight" border="8">common/box.png</texturefocus>
                 </control>
                 <control type="edit" id="11">
                     <align>left</align>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                     <texturefocus colordiffuse="Highlight" border="8">common/box.png</texturefocus>
                 </control>
                 <control type="button" id="12">
                     <align>left</align>
                     <label>1024</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                     <texturefocus colordiffuse="Highlight" border="8">common/box.png</texturefocus>
                 </control>
                 <control type="edit" id="13">
                     <align>left</align>
                     <label>1013</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                     <texturefocus colordiffuse="Highlight" border="8">common/box.png</texturefocus>
                 </control>
                 <control type="edit" id="14">
                     <align>left</align>
                     <label>1014</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                     <texturefocus colordiffuse="Highlight" border="8">common/box.png</texturefocus>
                 </control>
                 <control type="edit" id="15">
                     <align>left</align>
                     <label>15052</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                     <texturefocus colordiffuse="Highlight" border="8">common/box.png</texturefocus>
                 </control>
                 <control type="edit" id="16">
                     <align>left</align>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                     <texturefocus colordiffuse="Highlight" border="8">common/box.png</texturefocus>
                 </control>
             </control>

--- a/1080i/DialogPVRChannelManager.xml
+++ b/1080i/DialogPVRChannelManager.xml
@@ -131,7 +131,7 @@
                         <align>left</align>
                         <texturefocus colordiffuse="Highlight" border="5">common/box.png</texturefocus>
                         <label>19201</label>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                     </control>
                     <control type="button" id="9">
                         <description>Channel logo Button</description>

--- a/1080i/DialogPVRGuideSearch.xml
+++ b/1080i/DialogPVRGuideSearch.xml
@@ -30,7 +30,7 @@
                     <texturefocus colordiffuse="Highlight" border="5">common/box.png</texturefocus>
                     <texturenofocus colordiffuse="Black12" border="5">common/box.png</texturenofocus>
                     <label>19133</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                 </control>
                 <control type="textbox">
                     <description>Search help</description>

--- a/1080i/DialogPVRTimerSettings.xml
+++ b/1080i/DialogPVRTimerSettings.xml
@@ -53,7 +53,7 @@
                 <description>radioButton</description>
                 <texturefocus colordiffuse="Highlight" border="8">common/box.png</texturefocus>
                 <align>left</align>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
             </control>
             
             <control type="sliderex" id="13">

--- a/1080i/DialogPeripheralManager.xml
+++ b/1080i/DialogPeripheralManager.xml
@@ -43,7 +43,7 @@
                         <right>30</right>
                         <height>30</height>
                         <label>$INFO[ListItem.Label]</label>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                     </control>
 
                     <control type="label">

--- a/1080i/DialogSelect.xml
+++ b/1080i/DialogSelect.xml
@@ -31,7 +31,7 @@
                         <left>30</left>
                         <right>30</right>
                         <font>SmallBold</font>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <height>66</height>
                         <aligny>center</aligny>
                         <info>ListItem.Label</info>
@@ -40,7 +40,7 @@
                     <control type="label">
                         <left>30</left>
                         <right>30</right>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <align>right</align>
                         <height>66</height>
                         <aligny>center</aligny>
@@ -110,8 +110,8 @@
                         <width>496</width>
                         <height>135</height>
                         <font>SmallBold</font>
-                        <textcolor>Black70</textcolor>
-                        <selectedcolor>Black70</selectedcolor>
+                        <textcolor>DialogForeground</textcolor>
+                        <selectedcolor>DialogForeground</selectedcolor>
                         <info>ListItem.Label</info>
                         <animation effect="slide" end="0,18" condition="IsEmpty(ListItem.Property(Addon.Summary))">Conditional</animation>
                     </control>
@@ -121,8 +121,8 @@
                         <width>496</width>
                         <height>135</height>
                         <font>Mini</font>
-                        <textcolor>Black70</textcolor>
-                        <selectedcolor>Black70</selectedcolor>
+                        <textcolor>DialogForeground</textcolor>
+                        <selectedcolor>DialogForeground</selectedcolor>
                         <label>$INFO[ListItem.Property(Addon.Summary)]</label>
                     </control>
 
@@ -146,8 +146,8 @@
                             <width>496</width>
                             <height>135</height>
                             <font>SmallBold</font>
-                            <textcolor>Black70</textcolor>
-                            <selectedcolor>Black70</selectedcolor>
+                            <textcolor>DialogForeground</textcolor>
+                            <selectedcolor>DialogForeground</selectedcolor>
                             <info>ListItem.Label</info>
                             <animation effect="slide" end="0,18" condition="IsEmpty(ListItem.Property(Addon.Summary))">Conditional</animation>
                         </control>
@@ -157,8 +157,8 @@
                             <width>496</width>
                             <height>135</height>
                             <font>Mini</font>
-                            <textcolor>Black70</textcolor>
-                            <selectedcolor>Black70</selectedcolor>
+                            <textcolor>DialogForeground</textcolor>
+                            <selectedcolor>DialogForeground</selectedcolor>
                             <label>$INFO[ListItem.Property(Addon.Summary)]</label>
                         </control>
                     </control>
@@ -220,7 +220,7 @@
                 <onup>3</onup>
                 <ondown>3</ondown>
                 <font>Button</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
                 <texturefocus colordiffuse="Highlight" border="5">common/box.png</texturefocus>
                 <visible>Control.IsVisible(6)</visible>
             </control>
@@ -237,7 +237,7 @@
                 <onup>3</onup>
                 <ondown>3</ondown>
                 <font>Button</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
                 <texturefocus colordiffuse="Highlight" border="5">common/box.png</texturefocus>
                 <texturenofocus colordiffuse="Black12" border="5">common/box.png</texturenofocus>
                 <visible>!Control.IsVisible(6)</visible>

--- a/1080i/DialogSongInfo.xml
+++ b/1080i/DialogSongInfo.xml
@@ -38,50 +38,50 @@
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/3D.png</texture>
+                    <texture colordiffuse="DialogForeground">flags/3D.png</texture>
                     <visible>ListItem.IsStereoscopic</visible>
                 </control>
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/bluray.png</texture>
+                    <texture colordiffuse="DialogForeground">flags/bluray.png</texture>
                     <visible>[substring(ListItem.FilenameAndPath,bluray) | substring(ListItem.FilenameAndPath,bdrip) | substring(ListItem.FilenameAndPath,bd25) | substring(ListItem.FilenameAndPath,bd50)]</visible>
                 </control>
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/dvd.png</texture>
+                    <texture colordiffuse="DialogForeground">flags/dvd.png</texture>
                     <visible>substring(ListItem.FilenameAndPath,dvd)</visible>
                 </control>
 
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar1].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar1].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar2].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar2].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar3].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar3].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar4].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar4].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[MusicFlagstar5].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[MusicFlagstar5].png</texture>
                 </control>
                 
                 

--- a/1080i/DialogSubtitles.xml
+++ b/1080i/DialogSubtitles.xml
@@ -89,7 +89,7 @@
                         <height>24</height>
                         <aspectratio align="left">keep</aspectratio>
                         <texture>subs/icon_sync.png</texture>
-                        <colordiffuse>Black70</colordiffuse>
+                        <colordiffuse>DialogForeground</colordiffuse>
                         <visible>ListItem.property(sync)</visible>
                     </control>
 
@@ -99,7 +99,7 @@
                         <height>66</height>
                         <aligny>center</aligny>
                         <label>$INFO[ListItem.Label,,  •  ]$INFO[ListItem.Label2]</label>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <font>Small</font>
                     </control>
 
@@ -193,7 +193,7 @@
                 <bottom>15</bottom>
                 <align>left</align>
                 <font>Tiny</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
                 <label>$INFO[Control.GetLabel(140),,   ]$INFO[Player.FileName]</label>
             </control>
             

--- a/1080i/DialogTextViewer.xml
+++ b/1080i/DialogTextViewer.xml
@@ -21,7 +21,7 @@
                 <right>30</right>
                 <posy>48</posy>
                 <font>MediumBold</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
                 <height>45</height>
             </control>
 

--- a/1080i/DialogVideoInfo.xml
+++ b/1080i/DialogVideoInfo.xml
@@ -243,7 +243,7 @@
                     <width>100%</width>
                     <height>50</height>
                     <font>Mini</font>
-                    <textcolor>Black30</textcolor>
+                    <textcolor>DialogForeground30</textcolor>
                     <label>$INFO[ListItem.FilenameAndPath]</label>
                     <aligny>center</aligny>
                     <align>right</align>

--- a/1080i/DialogVideoInfo.xml
+++ b/1080i/DialogVideoInfo.xml
@@ -40,50 +40,50 @@
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/3D.png</texture>
+                    <texture colordiffuse="DialogForeground">flags/3D.png</texture>
                     <visible>ListItem.IsStereoscopic</visible>
                 </control>
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/bluray.png</texture>
+                    <texture colordiffuse="DialogForeground">flags/bluray.png</texture>
                     <visible>[substring(ListItem.FilenameAndPath,bluray) | substring(ListItem.FilenameAndPath,bdrip) | substring(ListItem.FilenameAndPath,bd25) | substring(ListItem.FilenameAndPath,bd50)]</visible>
                 </control>
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/dvd.png</texture>
+                    <texture colordiffuse="DialogForeground">flags/dvd.png</texture>
                     <visible>substring(ListItem.FilenameAndPath,dvd)</visible>
                 </control>
 
                 <control type="image">
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[Flagstar1].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[Flagstar1].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[Flagstar2].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[Flagstar2].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[Flagstar3].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[Flagstar3].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[Flagstar4].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[Flagstar4].png</texture>
                 </control>
                 <control type="image">
                     <posx>-48</posx>
                     <width>64</width>
                     <height>64</height>
-                    <texture colordiffuse="Black70">flags/$VAR[Flagstar5].png</texture>
+                    <texture colordiffuse="DialogForeground">flags/$VAR[Flagstar5].png</texture>
                 </control>
                 
                 

--- a/1080i/DialogVolumeBar.xml
+++ b/1080i/DialogVolumeBar.xml
@@ -20,7 +20,7 @@
                 <posy>0</posy>
                 <width>660</width>
                 <height>100</height>
-                <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
             </control>
 
             <control type="group">
@@ -53,7 +53,7 @@
                     <aligny>center</aligny>
                     <font>Tiny</font>
                     <label>$LOCALIZE[13376]$INFO[Player.Volume,  ,]</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                 </control>
                 
                 <control type="label">
@@ -64,7 +64,7 @@
                     <aligny>center</aligny>
                     <font>Tiny</font>
                     <label>$INFO[Control.GetLabel(1),, %]</label>
-                    <textcolor>Black70</textcolor>
+                    <textcolor>DialogForeground</textcolor>
                 </control>
 
                 <control type="progress">

--- a/1080i/FileBrowser.xml
+++ b/1080i/FileBrowser.xml
@@ -17,7 +17,7 @@
             <control type="image">
                 <width>1080</width>
                 <height>900</height>
-                <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
             </control>
 
             <control type="label" id="411">
@@ -27,7 +27,7 @@
                 <width>990</width>
                 <align>center</align>
                 <font>MediumBold</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
                 <label>1023</label>
             </control>
 
@@ -40,7 +40,7 @@
                 <width>750</width>
                 <haspath>true</haspath>
                 <font>Tiny</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
             </control>
 
             <control type="list" id="450">
@@ -70,8 +70,8 @@
                         <width>496</width>
                         <height>135</height>
                         <font>SmallBold</font>
-                        <textcolor>Black70</textcolor>
-                        <selectedcolor>Black70</selectedcolor>
+                        <textcolor>DialogForeground</textcolor>
+                        <selectedcolor>DialogForeground</selectedcolor>
                         <info>ListItem.Label</info>
                         <animation effect="slide" end="0,18" condition="IsEmpty(ListItem.Property(Addon.Summary))">Conditional</animation>
                     </control>
@@ -81,8 +81,8 @@
                         <width>496</width>
                         <height>135</height>
                         <font>Mini</font>
-                        <textcolor>Black70</textcolor>
-                        <selectedcolor>Black70</selectedcolor>
+                        <textcolor>DialogForeground</textcolor>
+                        <selectedcolor>DialogForeground</selectedcolor>
                         <label>$INFO[ListItem.Property(Addon.Summary)]</label>
                     </control>
 
@@ -106,8 +106,8 @@
                             <width>496</width>
                             <height>135</height>
                             <font>SmallBold</font>
-                            <textcolor>Black70</textcolor>
-                            <selectedcolor>Black70</selectedcolor>
+                            <textcolor>DialogForeground</textcolor>
+                            <selectedcolor>DialogForeground</selectedcolor>
                             <info>ListItem.Label</info>
                             <animation effect="slide" end="0,18" condition="IsEmpty(ListItem.Label2)">Conditional</animation>
                         </control>
@@ -117,8 +117,8 @@
                             <width>496</width>
                             <height>135</height>
                             <font>Mini</font>
-                            <textcolor>Black70</textcolor>
-                            <selectedcolor>Black70</selectedcolor>
+                            <textcolor>DialogForeground</textcolor>
+                            <selectedcolor>DialogForeground</selectedcolor>
                             <label>$INFO[ListItem.Label2]</label>
                         </control>
                     </control>

--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -200,12 +200,12 @@
         <radioposy>22</radioposy>
     </include>
     
-    <include name="DefLightBackground"><texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture></include>
+    <include name="DefLightBackground"><texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture></include>
     <include name="DefDarkBackground"><texture border="16" colordiffuse="Panel">common/rounded-shadow8.png</texture></include>
     <include name="DefLightBackgroundText">
-        <textcolor>Black70</textcolor>
-        <textureradiofocus colordiffuse="Black70">buttons/radio-on.png</textureradiofocus>
-        <textureradionofocus colordiffuse="Black30">buttons/radio-off.png</textureradionofocus>
+        <textcolor>DialogForeground</textcolor>
+        <textureradiofocus colordiffuse="DialogForeground">buttons/radio-on.png</textureradiofocus>
+        <textureradionofocus colordiffuse="DialogForeground30">buttons/radio-off.png</textureradionofocus>
     </include>
     <include name="DefDarkBackgroundText">
         <textcolor>White70</textcolor>

--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -89,7 +89,7 @@
     <include name="DefDialogButtons">
         <width>300</width>
         <font>Button</font>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <texturefocus colordiffuse="Highlight" border="5">common/box.png</texturefocus>
     </include>
     
@@ -131,7 +131,7 @@
         <width>990</width>
         <align>center</align>
         <font>MediumBold</font>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
     </include>
     
     <include name="DefDialogBackground">
@@ -143,7 +143,7 @@
         <control type="image">
             <width>1080</width>
             <height>900</height>
-            <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+            <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
         </control>
     </include>
     
@@ -157,7 +157,7 @@
             <posy>-30</posy>
             <width>960</width>
             <height>444</height>
-            <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+            <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
         </control>
 
         <control type="label" id="1">
@@ -185,7 +185,7 @@
         <align>left</align>
         <texturefocus colordiffuse="Highlight" border="5">common/box.png</texturefocus>
         <radioposx>540</radioposx>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
     </include>
     
     <include name="DefKeyboardKeys">

--- a/1080i/Includes_GlobalSearch.xml
+++ b/1080i/Includes_GlobalSearch.xml
@@ -9,7 +9,7 @@
         <height>40</height>
         <aligny>center</aligny>
         <font>TinyBold</font>
-        <textcolor>Black70</textcolor>
+        <textcolor>DialogForeground</textcolor>
         <align>left</align>
     </include>
     

--- a/1080i/SmartPlaylistEditor.xml
+++ b/1080i/SmartPlaylistEditor.xml
@@ -20,7 +20,7 @@
                 <posy>-30</posy>
                 <width>1200</width>
                 <height>1038</height>
-                <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
             </control>
 
             <control type="label" id="2">

--- a/1080i/SmartPlaylistRule.xml
+++ b/1080i/SmartPlaylistRule.xml
@@ -19,7 +19,7 @@
                 <posy>-30</posy>
                 <width>1260</width>
                 <height>480</height>
-                <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
             </control>
 
             <control type="label">

--- a/1080i/View_53_Poster.xml
+++ b/1080i/View_53_Poster.xml
@@ -147,7 +147,7 @@
                     <font>Tiny</font>
                     <label>$INFO[ListItem.Plot]</label>
                     <textcolor>Dark2</textcolor>
-                    <height>68</height>
+                    <height>128</height>
                     <align>justify</align>
                 </control>
             </control>

--- a/1080i/script-NextAired-TVGuide.xml
+++ b/1080i/script-NextAired-TVGuide.xml
@@ -18,7 +18,7 @@
                     <right>-8</right>
                     <top>-8</top>
                     <bottom>-8</bottom>
-                    <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                    <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
                 </control>
                 <control type="label" description="Searching">
                     <centerleft>50%</centerleft>

--- a/1080i/script-NextAired-TVGuide2.xml
+++ b/1080i/script-NextAired-TVGuide2.xml
@@ -18,7 +18,7 @@
                     <right>-8</right>
                     <top>-8</top>
                     <bottom>-8</bottom>
-                    <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                    <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
                 </control>
                 <control type="label" description="Searching">
                     <centerleft>50%</centerleft>

--- a/1080i/script-globalsearch-main.xml
+++ b/1080i/script-globalsearch-main.xml
@@ -18,7 +18,7 @@
                     <right>-8</right>
                     <top>-8</top>
                     <bottom>-8</bottom>
-                    <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                    <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
                 </control>
                 <control type="label" description="Searching">
                     <centerleft>50%</centerleft>

--- a/1080i/script-skinshortcuts.xml
+++ b/1080i/script-skinshortcuts.xml
@@ -16,7 +16,7 @@
                 <bottom>-8</bottom>
                 <left>-8</left>
                 <right>-8</right>
-                <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
+                <texture border="16" colordiffuse="DialogBackground">common/rounded-shadow8.png</texture>
             </control>
 
             <control type="label" id="500">
@@ -26,7 +26,7 @@
                 <width>1140</width>
                 <font>MediumBold</font>
                 <align>center</align>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
             </control>
             
             <!-- Center Buttons -->
@@ -113,7 +113,7 @@
                 <aligny>top</aligny>
                 <width>500</width>
                 <font>SmallBold</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
                 <label>Current Menu</label>
             </control>
             <!-- Left List: Current Shortcuts -->
@@ -174,7 +174,7 @@
                 <aligny>top</aligny>
                 <width>470</width>
                 <font>SmallBold</font>
-                <textcolor>Black70</textcolor>
+                <textcolor>DialogForeground</textcolor>
                 <label>31108</label>
             </control>
             <control type="button" id="102">
@@ -186,7 +186,7 @@
                 <onleft>103</onleft>
                 <ondown>111</ondown>
                 <onright>111</onright>
-                <texturenofocus flipy="false" colordiffuse="Black30">buttons/spin-down.png</texturenofocus>
+                <texturenofocus flipy="false" colordiffuse="DialogForeground30">buttons/spin-down.png</texturenofocus>
                 <texturefocus flipy="false" colordiffuse="Highlight">buttons/spin-down.png</texturefocus>
             </control>
             <control type="button" id="103">
@@ -198,7 +198,7 @@
                 <aligny>top</aligny>
                 <width>32</width>
                 <height>32</height>
-                <texturenofocus flipy="true" colordiffuse="Black30">buttons/spin-down.png</texturenofocus>
+                <texturenofocus flipy="true" colordiffuse="DialogForeground30">buttons/spin-down.png</texturenofocus>
                 <texturefocus flipy="true" colordiffuse="Highlight">buttons/spin-down.png</texturefocus>
             </control>
             <control type="list" id="111">
@@ -252,7 +252,7 @@
                         <left>30</left>
                         <right>30</right>
                         <info>ListItem.Label</info>
-                        <textcolor>Black70</textcolor>
+                        <textcolor>DialogForeground</textcolor>
                         <visible>!Control.HasFocus(111)</visible>
                     </control>
                 </focusedlayout>

--- a/colors/Dark.xml
+++ b/colors/Dark.xml
@@ -8,7 +8,8 @@
     
     
     <color name="Highlight">ff0385b5</color>
-
+    <color name="Highlight2">ffD19900</color>
+	
     <color name="Dark1">ffcccccc</color>
     <color name="Dark2">b3cccccc</color>
     <color name="Dark3">4dcccccc</color>
@@ -21,4 +22,8 @@
     <color name="Background">ff181818</color>
     <color name="FanartFade">2Fffffff</color>
     <color name="FloorFade">BF181818</color>
+	
+	<color name="DialogBackground">ff333333</color>
+	<color name="DialogForeground">b3cccccc</color>
+	<color name="DialogForeground30">4dcccccc</color>
 </colors>

--- a/colors/Defaults.xml
+++ b/colors/Defaults.xml
@@ -9,6 +9,7 @@
     <color name="Highlight">ff0385b5</color>
     <color name="Highlight2">FFff4081</color>
     <color name="Selected">FFededed</color>
+ 
     <color name="Dark1">ff333333</color>
     <color name="Dark2">b3333333</color>
     <color name="Dark3">4d333333</color>
@@ -34,4 +35,8 @@
     <color name="Black70">B3000000</color>
     <color name="Black30">4D000000</color>
     <color name="Black12">1F000000</color>
+	
+	<color name="DialogBackground">ffdddddd</color>
+	<color name="DialogForeground">B3000000</color>
+	<color name="DialogForeground30">4D000000</color>
 </colors>


### PR DESCRIPTION
The Dialogs now use DialogForeground as Font Color, DialogForeground30
as unchecked or unfocused color and DialogBackground as Background Color

I also changed the height of the plot text on the poster view to 4 lines instead of 2