### PR TITLE
Changed Aspect Ratio of Poster on Wall View

### DIFF
--- a/1080i/View_55_Wall.xml
+++ b/1080i/View_55_Wall.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <includes>
-    <include name="55Width-NoInfo"><width>1362</width></include>
+    <include name="55Width-NoInfo"><width>1340</width></include>
     <include name="55Width-Info"><width>1135</width></include>
     <include name="View_55_Wall">
     
@@ -26,7 +26,7 @@
                     <pagecontrol>60</pagecontrol>
                     <viewtype label="536">list</viewtype>
                     <scrolltime tween="quadratic">400</scrolltime>
-                    <itemlayout height="330" width="227">
+                    <itemlayout height="330" width="223">
                         <control type="image">
                             <width>100%</width>
                             <height>100%</height>
@@ -51,7 +51,7 @@
                             <visible>stringcompare(ListItem.Overlay,OverlayWatched.png)</visible>
                         </control>
                     </itemlayout>
-                    <focusedlayout height="330" width="227">
+                    <focusedlayout height="330" width="223">
                         <control type="group">
                             <control type="image">
                                 <width>100%</width>
@@ -102,7 +102,7 @@
     <include name="55Info-Poster">
         <control type="group">
             <left>70</left>
-            <width>418</width>
+            <width>440</width>
             <top>206</top>
             <height>660</height>
             <control type="image">
@@ -123,7 +123,7 @@
                 <right>10</right>
                 <bottom>10</bottom>
                 <fadetime>300</fadetime>
-                <aspectratio align="center" aligny="center" scalediffuse="false">stretch</aspectratio>
+                <aspectratio align="center" aligny="center" scalediffuse="false">scale</aspectratio>
                 <texture diffuse="diffuse/listposter.png" background="true">$VAR[PosterImage]</texture>
             </control>
             <control type="group">


### PR DESCRIPTION
Changed the Aspect Ratio of the Poster on the Wall view from 1.58 to
1.5. to do this i had to change the small posters aspect ratios from
1.45 to 1.48 which is good because its closer to 1.5

Hey Jurialmunkey, the aspect ratio of the Posters on the Wall drove me mad so i changed it, maybe you want to change it too?