### PR TITLE
Added arial fontset for Unicode support

### DIFF
--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <fonts>
-    <fontset id="default" unicode="true">
+    <fontset id="Default" unicode="true">
 
         <font>
             <name>LargeBold</name>
@@ -227,6 +227,121 @@
         <font>
             <name>font13</name>
             <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>30</size>
+        </font>
+
+    </fontset>
+    
+    <fontset id="Arial" unicode="true">
+
+        <font>
+            <name>LargeBold</name>
+            <style>uppercase</style>
+            <filename>arial.ttf</filename>
+            <size>48</size>
+        </font>
+        <font>
+            <name>Large</name>
+            <filename>arial.ttf</filename>
+            <size>48</size>
+        </font>
+        <font>
+            <name>EpisodeNumber</name>
+            <filename>arial.ttf</filename>
+            <size>100</size>
+        </font>
+        <font>
+            <name>Medium</name>
+            <filename>arial.ttf</filename>
+            <size>38</size>
+        </font>
+        <font>
+            <name>MediumBold</name>
+            <filename>arial.ttf</filename>
+            <size>38</size>
+        </font>
+        
+        <font>
+            <name>Small</name>
+            <filename>arial.ttf</filename>
+            <size>30</size>
+        </font>
+        <font>
+            <name>SmallBold</name>
+            <filename>arial.ttf</filename>
+            <size>32</size>
+        </font>
+        
+      
+        <font>
+            <name>Tiny</name>
+            <filename>arial.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
+            <name>TinyBold</name>
+            <filename>arial.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
+            <name>Mini</name>
+            <filename>arial.ttf</filename>
+            <size>24</size>
+        </font>
+        <font>
+            <name>Button</name>
+            <style>uppercase</style>
+            <filename>arial.ttf</filename>
+            <size>24</size>
+        </font>
+        
+        <font>
+            <name>Flag</name>
+            <style>uppercase</style>
+            <filename>arial.ttf</filename>
+            <size>22</size>
+        </font>
+        <font>
+            <name>EPGTimeline</name>
+            <filename>arial.ttf</filename>
+            <size>20</size>
+            <style>uppercase</style>
+        </font>
+        <font>
+            <name>Home</name>
+            <style>uppercase</style>
+            <filename>arial.ttf</filename>
+            <size>32</size>
+        </font>
+        <font>
+            <name>HomeIcon</name>
+            <style>uppercase</style>
+            <filename>arial.ttf</filename>
+            <size>26</size>
+        </font>
+        
+        <font>
+            <name>WidgetSelector</name>
+            <style>uppercase</style>
+            <filename>arial.ttf</filename>
+            <size>22</size>
+        </font>
+        
+        <font>
+            <name>Weather</name>
+            <filename>Weather.ttf</filename>
+            <size>64</size>
+        </font>
+        <font>
+            <name>BigWeather</name>
+            <filename>Weather.ttf</filename>
+            <size>160</size>
+        </font>
+        
+        <!-- Required for system -->
+        <font>
+            <name>font13</name>
+            <filename>arial.ttf</filename>
             <size>30</size>
         </font>
 


### PR DESCRIPTION
I added a new fontset using the default arial.ttf bundled with Kodi for better Unicode compatibility.

Unfortunately, finding a Condensed font that supports Unicode is very difficult, so it would most likely require patching the bundled font (I may try that at a later date. Maybe using RobotoCondensed patched with DroidSansFallback ?)

Also corrected capitalization for the sets' names (Default didn't start with a capital letter but Large did. All other items in the menu have a capital as well, so changed "default" to "Default").