### PR TITLE
Correct overlapping of the CPU info text label

### DIFF
--- a/1080i/SettingsSystemInfo.xml
+++ b/1080i/SettingsSystemInfo.xml
@@ -143,8 +143,9 @@
                         <description>CPU Text</description>
                         <font>Tiny</font>
                         <posy>-60</posy>
+                        <posx>750</posx>
                         <align>right</align>
-                        <width>750</width>
+                        <width>600</width>
                         <height>60</height>
                         <label>$INFO[System.CPUUsage]</label>
                         <include>DefSettingsButton</include>


### PR DESCRIPTION
## Before:
![2015-07-04-01 23-screenshot](https://cloud.githubusercontent.com/assets/1421724/8507197/648a5ae4-21ec-11e5-99b1-26579d8c2c99.png)

## After:
![2015-07-04-01 22-screenshot](https://cloud.githubusercontent.com/assets/1421724/8507198/691d4d50-21ec-11e5-8d68-2ddc01f6f381.png)

The only concern here (and I'm not sure how solveable this is) is the size of the label in other languages.