### PR TITLE
Added new viewtype: Icon Wall

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -15,10 +15,10 @@
     <include file="View_57_ExtraInfo.xml" />
     <include file="View_58_Cards.xml" />
     <include file="View_59_BannerWall.xml" />
-    <include file="View_508_BigWall.xml" />
     <include file="View_500_Thumbnails.xml" />
     <include file="View_503_Poster_Square.xml" />
     <include file="View_505_Wall_Square.xml" />
+    <include file="View_508_BigWall.xml" />
     
     
     <include file="Includes_Furniture.xml" />

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -15,6 +15,7 @@
     <include file="View_57_ExtraInfo.xml" />
     <include file="View_58_Cards.xml" />
     <include file="View_59_BannerWall.xml" />
+    <include file="View_508_BigWall.xml" />
     <include file="View_500_Thumbnails.xml" />
     <include file="View_503_Poster_Square.xml" />
     <include file="View_505_Wall_Square.xml" />

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -1018,6 +1018,7 @@
             <include>Animation.FadeOut</include>
             <visible>Skin.HasSetting(furniture.logo)</visible>
             <visible>!Window.IsVisible(script-ExtendedInfo Script-DialogVideoInfo.xml) + !Window.IsVisible(script-ExtendedInfo Script-DialogInfo.xml)</visible>
+            <visible>!Control.IsVisible(508)</visible>
             <centertop>120</centertop>
             <centerleft>50%</centerleft>
             <width>400</width>

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -15,6 +15,23 @@
             <animation effect="fade" start="100" end="33" time="400" condition="!Control.HasFocus(60) + !Container.Scrolling">Conditional</animation>
         </control>
     </include>
+
+    <include name="Furniture_Scrollbar_Wall">
+        <control type="scrollbar" id="60">
+            <onback>50</onback>
+            <centerright>60</centerright>
+            <posy>PosterPad</posy>
+            <top>50</top>
+            <height>979</height>
+            <width>8</width>
+            <onleft>50</onleft>
+            <onright condition="!Skin.HasSetting(global.kioskmode)">9000</onright>
+            <texturesliderbackground border="4" colordiffuse="Dark4">scrollbar/scrollv.png</texturesliderbackground>
+            <texturesliderbar border="4" colordiffuse="Dark3">scrollbar/scrollv.png</texturesliderbar>
+            <texturesliderbarfocus border="4" colordiffuse="Dark2">scrollbar/scrollv.png</texturesliderbarfocus>
+            <animation effect="fade" start="100" end="33" time="400" condition="!Control.HasFocus(60) + !Container.Scrolling">Conditional</animation>
+        </control>
+    </include>
     
     <include name="Furniture_Scrollbar_Horizontal">
         <control type="scrollbar" id="60">
@@ -200,6 +217,7 @@
             <visible>!Skin.HasSetting(furniture.flags)</visible>
             <visible>!Window.IsVisible(script-ExtendedInfo Script-DialogVideoInfo.xml)</visible>
             <visible>!Window.IsVisible(script-ExtendedInfo Script-DialogInfo.xml)</visible>
+            <visible>!Control.IsVisible(508)</visible>
             <visible>Container.Content(movies) | Container.Content(episodes) | Container.Content(tvshows) | Container.Content(seasons)</visible>
             <visible>!stringcompare(ListItem.Label,..)</visible>
             <include>Animation.FadeIn</include>
@@ -1011,6 +1029,7 @@
             <top>SidePad</top>
             <left>SidePad</left>
             <visible>!Skin.HasSetting(furniture.header)</visible>
+            <visible>!Control.IsVisible(508)</visible>
             <include>Animation.FurnitureFadeInOut</include>
             <orientation>horizontal</orientation>
             <itemgap>24</itemgap>
@@ -1094,6 +1113,7 @@
             <include>Animation.FurnitureFadeInOut</include>
             <centerbottom>NavBarPad</centerbottom>
             <visible>!Skin.HasSetting(furniture.clock)</visible>
+            <visible>!Control.IsVisible(508)</visible>
             <height>84</height>
             <animation effect="slide" start="0" end="0,-10" time="150" condition="Skin.HasSetting(furniture.weather)">Conditional</animation>
             <control type="label">
@@ -1150,6 +1170,7 @@
             <visible>!Window.IsVisible(DialogExtendedProgressBar.xml)</visible>
             <visible>!Window.IsActive(DialogKaiToast.xml)</visible>
             <visible>Skin.HasSetting(furniture.nowplaying) | [!Skin.HasSetting(furniture.nowplaying) + IsEmpty(Player.Duration) + !Player.HasAudio]</visible>
+            <visible>!Control.IsVisible(508)</visible>
             <top>70</top>
             <right>62</right>
             <orientation>horizontal</orientation>
@@ -1198,6 +1219,7 @@
             <visible>!Window.IsVisible(DialogVolumeBar.xml)</visible>
             <visible>!Window.IsVisible(DialogKaiToast.xml)</visible>
             <visible>!Window.IsVisible(DialogExtendedProgressBar.xml)</visible>
+            <visible>!Control.IsVisible(508)</visible>
             <include>Animation.FurnitureFadeInOut</include>
             <visible>IsEmpty(Window(10025).Property(TvTunesIsAlive))</visible>
             <visible>!Window.IsActive(DialogKaiToast.xml)</visible>

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -3,7 +3,7 @@
 <window id="6">
     <defaultcontrol always="true">50</defaultcontrol>
     <menucontrol>9000</menucontrol>
-    <views>50,550,56,57,53,55,555,59,54,51,58,52,500</views>
+    <views>50,550,56,57,53,55,508,555,59,54,51,58,52,500</views>
     <onload condition="System.HasAddon(script.tv.show.next.aired)">RunScript(script.tv.show.next.aired,backend=True)</onload>
     
     <controls>
@@ -31,6 +31,7 @@
         <include>View_58_Cards</include>
         <include>View_59_BannerWall</include>
         <include>View_500_Thumbnails</include>
+        <include>View_508_BigWall</include>
         
         <include>Furniture_Header</include>
         <include>Furniture_NowPlaying</include>

--- a/1080i/View_508_BigWall.xml
+++ b/1080i/View_508_BigWall.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Foundation -->
+<includes>
+    <include name="View_508_BigWall">    
+        <control type="group">
+            <include>Animation.Common</include>
+            <visible>Control.IsVisible(508)</visible>
+            <control type="panel" id="508">
+                <visible>substring(Container.FolderPath,plugin://plugin.program.advanced.launcher/,left) | Container.Content(musicvideos) | Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(sets)</visible>
+                <top>40</top>
+                <right>70</right>
+                <left>70</left>
+                <height>1011</height>
+                <onleft condition="!Skin.HasSetting(global.kioskmode)">9000</onleft>
+                <onright>60</onright>
+                <onup>508</onup>
+                <ondown>508</ondown>
+                <preloaditems>2</preloaditems>
+                <pagecontrol>60</pagecontrol>
+                <viewtype label="31274">list</viewtype>
+                <scrolltime tween="quadratic">400</scrolltime>
+                <itemlayout height="337" width="222">
+                    <control type="image">
+                        <left>0</left>
+                        <top>0</top>
+                        <right>0</right>
+                        <bottom>12</bottom>
+                        <texture border="10">common/nofocus-shadow10.png</texture>
+                    </control>
+                    <control type="image">
+                        <left>10</left>
+                        <top>10</top>
+                        <right>10</right>
+                        <bottom>22</bottom>
+                        <aspectratio scalediffuse="false">scale</aspectratio>
+                        <texture diffuse="diffuse/wall.png" background="true">$VAR[PosterImage]</texture>
+                    </control>
+                    <control type="image">
+                        <centerright>32</centerright>
+                        <centertop>32</centertop>
+                        <width>32</width>
+                        <height>32</height>
+                        <aspectratio aligny="top">keep</aspectratio>
+                        <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
+                        
+                        <visible>!stringcompare(ListItem.Label,..)</visible>
+                    </control>
+                    <control type="image">
+                        <centerright>32</centerright>
+                        <centertop>32</centertop>
+                        <width>32</width>
+                        <height>32</height>
+                        <aspectratio aligny="top">keep</aspectratio>
+                        <texture>$VAR[PosterPercentWatched]</texture>
+                        <visible>!stringcompare(ListItem.Label,..)</visible>
+                        
+                    </control>
+                </itemlayout>
+                <focusedlayout height="337" width="222">
+                    <control type="image">
+                        <left>0</left>
+                        <top>0</top>
+                        <right>0</right>
+                        <bottom>12</bottom>
+                        <texture border="10">common/nofocus-shadow10.png</texture>
+                    </control>
+                    <control type="image">
+                        <left>10</left>
+                        <top>10</top>
+                        <right>10</right>
+                        <bottom>22</bottom>
+                        <aspectratio scalediffuse="false">scale</aspectratio>
+                        <texture diffuse="diffuse/wall.png" background="true">$VAR[PosterImage]</texture>
+                    </control>
+                    <control type="image">
+                        <centerright>32</centerright>
+                        <centertop>32</centertop>
+                        <width>32</width>
+                        <height>32</height>
+                        <aspectratio aligny="top">keep</aspectratio>
+                        <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
+                        
+                        <visible>!stringcompare(ListItem.Label,..)</visible>
+                    </control>
+                    <control type="image">
+                        <centerright>32</centerright>
+                        <centertop>32</centertop>
+                        <width>32</width>
+                        <height>32</height>
+                        <aspectratio aligny="top">keep</aspectratio>
+                        <texture>$VAR[PosterPercentWatched]</texture>
+                        <visible>!stringcompare(ListItem.Label,..)</visible>
+                        
+                    </control>
+                    <control type="image">
+                        <left>3</left>
+                        <top>3</top>
+                        <right>3</right>
+                        <bottom>15</bottom>
+                        <texture colordiffuse="$VAR[ColorHighlight]" border="20">common/selectbox.png</texture>
+                        <animation type="Focus">
+                            <effect type="zoom" start="90" end="100" time="150" tween="sine" easing="inout" center="auto" />
+                            <effect type="fade" start="0" end="100" time="150" tween="sine" easing="in" />
+                        </animation>
+                        <animation type="Unfocus">
+                            <effect type="zoom" start="100" end="90" time="150" tween="sine" easing="inout" center="auto" />
+                            <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
+                        </animation>
+                    </control>
+                      
+                </focusedlayout>
+            </control>
+            <include>Furniture_Scrollbar_Wall</include>
+        </control>   
+    </include>
+</includes>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -707,3 +707,7 @@ msgstr ""
 msgctxt "#31273"
 msgid "Hub widget"
 msgstr ""
+
+msgctxt "#31274"
+msgid "Icon Wall"
+msgstr ""


### PR DESCRIPTION
I'm not sure if this viewtype fits with your vision of the skin, but I find it's nice for scrolling through large movie libraries.

![icon-wall-view](https://cloud.githubusercontent.com/assets/16982813/13200225/89a6bcba-d7f3-11e5-8a69-28f378177fd2.jpg)

As this is my first attempt at skin editing you may wish to review the changes, but I couldn't find anything wrong when I tested it.

(View_508_BigWall.xml is an edited version of View_55_Wall.xml)