### PR TITLE
Remove trailing whitespace

### DIFF
--- a/1080i/Custom_AutoAS.xml
+++ b/1080i/Custom_AutoAS.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <window type="dialog" id="1108">
-    
+
     <onload condition="System.HasAddon(script.artistslideshow) + !Skin.HasSetting(ArtistSlideShow.Disabled)">RunScript(script.artistslideshow)</onload>
     <visible>Player.HasAudio</visible>
     <controls></controls>
-</window> 
+</window>

--- a/1080i/Custom_DirectorMovies.xml
+++ b/1080i/Custom_DirectorMovies.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1103">
     <defaultcontrol always="true">9500</defaultcontrol>
-    
+
     <onunload>ClearProperty(content)</onunload>
     <controls>
         <include>GlobalBackground</include>
@@ -64,7 +64,7 @@
                 <visible>Container(9500).IsUpdating</visible>
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>
-          
+
                 <control type="image">
                     <description>Busy animation</description>
                     <centerleft>54</centerleft>
@@ -196,17 +196,17 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
                 <content>$VAR[DefDirectorWindowContent]</content>
             </control>
-        
+
             <control type="grouplist">
                 <visible>!Container(9500).IsUpdating</visible>
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>
                 <left>SidePad</left>
-                
+
                 <right>SidePad</right>
                 <orientation>vertical</orientation>
                 <top>695</top>

--- a/1080i/Custom_Hub_1111.xml
+++ b/1080i/Custom_Hub_1111.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1111">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1111" />

--- a/1080i/Custom_Hub_1112.xml
+++ b/1080i/Custom_Hub_1112.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1112">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1112" />

--- a/1080i/Custom_Hub_1113.xml
+++ b/1080i/Custom_Hub_1113.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1113">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1113" />

--- a/1080i/Custom_Hub_1114.xml
+++ b/1080i/Custom_Hub_1114.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1114">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1114" />

--- a/1080i/Custom_Hub_1115.xml
+++ b/1080i/Custom_Hub_1115.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1115">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1115" />

--- a/1080i/Custom_Hub_1116.xml
+++ b/1080i/Custom_Hub_1116.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1116">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1116" />

--- a/1080i/Custom_Hub_1117.xml
+++ b/1080i/Custom_Hub_1117.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1117">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1117" />

--- a/1080i/Custom_Hub_1118.xml
+++ b/1080i/Custom_Hub_1118.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1118">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1118" />

--- a/1080i/Custom_Hub_1119.xml
+++ b/1080i/Custom_Hub_1119.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1119">
     <defaultcontrol always="true">9501</defaultcontrol>
-    
+
     <controls>
         <include content="DefHubWindow">
             <param name="list" value="skinshortcuts-group-x1119" />

--- a/1080i/Custom_MovieDB_Movies.xml
+++ b/1080i/Custom_MovieDB_Movies.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1104">
     <defaultcontrol always="true">9500</defaultcontrol>
-    
+
     <onunload>ClearProperty(content)</onunload>
     <controls>
         <include>GlobalBackground</include>
@@ -75,7 +75,7 @@
                 <visible>Container(9500).IsUpdating</visible>
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>
-          
+
                 <control type="image">
                     <description>Busy animation</description>
                     <centerleft>54</centerleft>
@@ -207,17 +207,17 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
                 <content>$VAR[DefMovieDBMoviesContent]</content>
             </control>
-        
+
             <control type="grouplist">
                 <visible>!Container(9500).IsUpdating</visible>
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>
                 <left>SidePad</left>
-                
+
                 <right>SidePad</right>
                 <orientation>vertical</orientation>
                 <top>695</top>
@@ -236,7 +236,7 @@
                     <textcolor>Dark2</textcolor>
                     <label>$INFO[Container(9500).ListItem.Premiered]$INFO[Container(9500).ListItem.Rating,  •  ,]$INFO[Container(9500).ListItem.Votes, (, $LOCALIZE[20350])]</label>
                 </control>
-                
+
             </control>
         </control>
     </controls>

--- a/1080i/Custom_MovieDB_Shows.xml
+++ b/1080i/Custom_MovieDB_Shows.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1105">
     <defaultcontrol always="true">9500</defaultcontrol>
-    
+
     <onunload>ClearProperty(content)</onunload>
     <controls>
         <include>GlobalBackground</include>
@@ -75,7 +75,7 @@
                 <visible>Container(9500).IsUpdating</visible>
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>
-          
+
                 <control type="image">
                     <description>Busy animation</description>
                     <centerleft>54</centerleft>
@@ -207,17 +207,17 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
                 <content>$VAR[DefMovieDBEpisodesContent]</content>
             </control>
-        
+
             <control type="grouplist">
                 <visible>!Container(9500).IsUpdating</visible>
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>
                 <left>SidePad</left>
-                
+
                 <right>SidePad</right>
                 <orientation>vertical</orientation>
                 <top>695</top>
@@ -236,7 +236,7 @@
                     <textcolor>Dark2</textcolor>
                     <label>$INFO[Container(9500).ListItem.Rating]$INFO[Container(9500).ListItem.Votes, (, $LOCALIZE[20350])]</label>
                 </control>
-                
+
             </control>
         </control>
     </controls>

--- a/1080i/Custom_SetCustomColor.xml
+++ b/1080i/Custom_SetCustomColor.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="window" id="1107">
     <defaultcontrol always="true">9500</defaultcontrol>
-    
+
     <controls>
         <include>GlobalBackground</include>
         <include>Furniture_Header</include>
@@ -72,7 +72,7 @@
                     </control>
                 </itemlayout>
                 <focusedlayout height="160" width="160">
-               
+
                     <control type="image">
                         <left>0</left>
                         <top>0</top>
@@ -118,7 +118,7 @@
                         <onclick>Close</onclick>
                         <thumb>special://skin/extras/icons/error.png</thumb>
                         <label>571</label>
-                    </item>                    
+                    </item>
                     <item id="2"> <!--green 1 -->
                         <onclick>Skin.SetString(focuscolor.name,FF93ce5f)</onclick>
                         <onclick>Close</onclick>

--- a/1080i/Custom_WidgetSelect.xml
+++ b/1080i/Custom_WidgetSelect.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="1106" type="dialog">
     <defaultcontrol always="true">9000</defaultcontrol>
-    
+
     <controls>
 
         <include>GlobalOverlay</include>

--- a/1080i/Defaults.xml
+++ b/1080i/Defaults.xml
@@ -158,7 +158,7 @@
         <pulseonselect>false</pulseonselect>
     </default>
 
-    
+
 
     <default type="progress">
         <texturebg colordiffuse="2f5f5f5f">osd/progress-bg.png</texturebg>
@@ -178,7 +178,7 @@
         <textureslidernib border="2">other_textures/OSD/SliderNibNF.png</textureslidernib>
         <textureslidernibfocus border="2">other_textures/OSD/SliderNibFO.png</textureslidernibfocus>
     </default>
-    
+
     <default type="sliderex">
         <height>66</height>
         <orientation>horizontal</orientation>
@@ -207,8 +207,8 @@
         <showonepage>false</showonepage>
         <orientation>vertical</orientation>
     </default>
-    
-    
+
+
 
     <default type="textbox">
         <font>Small</font>

--- a/1080i/DeleteTimer.xml
+++ b/1080i/DeleteTimer.xml
@@ -6,12 +6,12 @@
 
         <control type="group">
             <include>DefDialogBackground</include>
-            
+
             <control type="label" id="20">
                 <include>DefDialogHeader</include>
                 <label>$ADDON[pvr.wmc 30120]</label>
             </control>
-  
+
             <control type="grouplist" id="9002">
                 <description>Control Area</description>
                 <left>38</left>
@@ -69,6 +69,6 @@
             </control>
 
         </control>
-    
+
     </controls>
 </window>

--- a/1080i/DialogAddonInfo.xml
+++ b/1080i/DialogAddonInfo.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="146">
     <defaultcontrol always="true">9000</defaultcontrol>
-    
+
 
     <controls>
         <control type="group">
@@ -88,7 +88,7 @@
                     </control>
                 </control>
 
-                
+
 
                 <!-- Info -->
                 <control type="group">
@@ -220,7 +220,7 @@
                     </control>
                 </control>
 
-               
+
             </control>
         </control>
     </controls>

--- a/1080i/DialogAddonSettings.xml
+++ b/1080i/DialogAddonSettings.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="10140">
     <defaultcontrol always="true">9</defaultcontrol>
-    
+
 
     <controls>
 

--- a/1080i/DialogAudioDSPManager.xml
+++ b/1080i/DialogAudioDSPManager.xml
@@ -8,7 +8,7 @@
         <control type="group">
             <width>1780</width>
             <include>DefDialogBackground</include>
-        
+
             <control type="group">
                 <control type="label" id="2">
                     <include>DefDialogHeader</include>
@@ -75,7 +75,7 @@
                     </focusedlayout>
                 </control>
             </control>
-            
+
             <control type="group" id="200">
                 <description>available- and active mode lists</description>
                 <left>20</left>
@@ -209,7 +209,7 @@
                         <height>100%</height>
                         <texture colordiffuse="Black12" border="5">common/box.png</texture>
                     </control>
-                    
+
                     <control type="panel" id="21">
                         <description>available modes list</description>
                         <width>100%</width>
@@ -303,7 +303,7 @@
                     </control>
                 </control>
             </control>
-            
+
             <control type="grouplist" id="9001">
                 <left>20</left>
                 <right>20</right>

--- a/1080i/DialogBusy.xml
+++ b/1080i/DialogBusy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <window id="136">
-    
+
 
     <controls>
 

--- a/1080i/DialogButtonMenu.xml
+++ b/1080i/DialogButtonMenu.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="buttonMenu" id="111">
     <defaultcontrol always="true">3110</defaultcontrol>
-    
+
     <zorder>10</zorder>
     <controls>
 
@@ -81,7 +81,7 @@
                     <onclick>Powerdown()</onclick>
                     <visible>System.CanPowerDown</visible>
                 </control>
-                
+
                 <control type="button" id="3114">
                     <description>Custom Shutdown Timer button</description>
                     <include>DefContextButton</include>
@@ -122,31 +122,31 @@
                     <onclick>XBMC.Reset()</onclick>
                     <visible>System.CanReboot</visible>
                 </control>
-                
+
                 <control type="button" id="3121">
                     <include>DefContextButton</include>
                     <label>5</label>
                     <onclick>ActivateWindow(settings)</onclick>
                 </control>
-                
+
                 <control type="button" id="3122">
                     <include>DefContextButton</include>
                     <label>130</label>
                     <onclick>ActivateWindow(systeminfo)</onclick>
                 </control>
-                
+
                 <control type="button" id="3123">
                     <include>DefContextButton</include>
                     <label>10003</label>
                     <onclick>ActivateWindow(filemanager)</onclick>
                 </control>
-                
+
                 <control type="button" id="3120">
                     <include>DefContextButton</include>
                     <label>31195</label>
                     <onclick>ReloadSkin()</onclick>
                 </control>
-                
+
             </control>
 
         </control>

--- a/1080i/DialogContextMenu.xml
+++ b/1080i/DialogContextMenu.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="106">
     <defaultcontrol always="true">1000</defaultcontrol>
-    
+
 
     <coordinates>
         <origin x="0" y="0" />

--- a/1080i/DialogExtendedProgressBar.xml
+++ b/1080i/DialogExtendedProgressBar.xml
@@ -41,7 +41,7 @@
                         <colordiffuse>Dark1</colordiffuse>
                         <animation effect="fade" start="0" end="100" time="150">VisibleChange</animation>
                     </control>
-                    
+
                     <control type="image">
                         <centerleft>50%</centerleft>
                         <centertop>50%</centertop>
@@ -71,7 +71,7 @@
 
             </control>
         </control>
-       
+
         <control type="progress" id="32">
             <texturebg>-</texturebg>
             <lefttexture>-</lefttexture>

--- a/1080i/DialogFavourites.xml
+++ b/1080i/DialogFavourites.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="dialog" id="134">
     <defaultcontrol always="true">450</defaultcontrol>
-    
+
 
     <controls>
 
@@ -19,7 +19,7 @@
                 <height>900</height>
                 <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
             </control>
-            
+
             <control type="label" id="1">
                 <description>header label</description>
                 <centerleft>50%</centerleft>
@@ -192,7 +192,7 @@
                 <texture fallback="DefaultAddonNone.png">$INFO[Container(450).ListItem.Icon]</texture>
                 <aspectratio align="center" aligny="bottom">keep</aspectratio>
             </control>
-            
+
             <control type="image">
                 <posx>705</posx>
                 <top>120</top>

--- a/1080i/DialogFullScreenInfo.xml
+++ b/1080i/DialogFullScreenInfo.xml
@@ -4,8 +4,8 @@
     <defaultcontrol always="true">603</defaultcontrol>
     <onunload>ClearProperty(osdshowinfo,home)</onunload>
     <controls>
-        
-    
+
+
     </controls>
 
 </window>

--- a/1080i/DialogGameControllers.xml
+++ b/1080i/DialogGameControllers.xml
@@ -57,7 +57,7 @@
                 <ondown>8000</ondown>
                 <itemgap>20</itemgap>
             </control>
-            
+
             <control type="grouplist" id="8000">
                 <left>0</left>
                 <right>0</right>

--- a/1080i/DialogKeyboard.xml
+++ b/1080i/DialogKeyboard.xml
@@ -9,7 +9,7 @@
             <visible>!Window.IsVisible(numericinput)</visible>
             <include>Animation.ZoomIn</include>
             <include>Animation.FadeOut</include>
-            
+
             <centerleft>50%</centerleft>
             <centertop>60%</centertop>
             <height>522</height>
@@ -417,7 +417,7 @@
                         <ondown>8000</ondown>
                         <include>DefKeyboardKeys</include>
                     </control>
-                    
+
                     <control type="button" id="32">
                         <description>Layout</description>
                         <width>655</width>
@@ -449,9 +449,9 @@
                         <ondown>8000</ondown>
                     </control>
                 </control>
-            
+
             </control>
-        
+
             <control type="group">
                 <width>100%</width>
                 <height>89</height>

--- a/1080i/DialogMediaSource.xml
+++ b/1080i/DialogMediaSource.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="129">
     <defaultcontrol always="true">10</defaultcontrol>
-    
+
 
     <controls>
 
@@ -10,12 +10,12 @@
 
         <control type="group">
             <include>DefDialogBackground</include>
-            
+
             <control type="label" id="2">
                 <include>DefDialogHeader</include>
                 <label>1026</label>
             </control>
-            
+
             <control type="image">
                 <posx>705</posx>
                 <top>120</top>

--- a/1080i/DialogMusicInfo.xml
+++ b/1080i/DialogMusicInfo.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="2001">
     <defaultcontrol always="true">9000</defaultcontrol>
-    
+
     <onload>ClearProperty(content)</onload>
     <onload>ClearProperty(tracklist)</onload>
     <onload>Dialog.Close(135)</onload>
@@ -31,7 +31,7 @@
                 <animation effect="slide" start="0" end="1920" time="300" tween="quadratic" easing="in">WindowClose</animation>
                 <animation effect="slide" start="1920" end="0" delay="0" time="300" tween="quadratic" easing="out">Visible</animation>
                 <animation effect="slide" start="0" end="1920" time="300" tween="quadratic" easing="in">Hidden</animation>
-          
+
                 <control type="group">
                     <include>Animation.DelayFadeIn</include>
                     <visible>Control.HasFocus(51) | [Control.HasFocus(9501) + Control.IsVisible(9501)]</visible>
@@ -120,7 +120,7 @@
                     </control> -->
                 </control>
 
-                
+
 
                 <!-- Album Info -->
                 <control type="group">
@@ -152,7 +152,7 @@
                                 <aligny>center</aligny>
                             </control>
                         </control>
-                        
+
                         <control type="group">
                             <height>36</height>
                             <control type="label">
@@ -568,7 +568,7 @@
                     <visible>Control.IsVisible(9501)</visible>
                     <include>Animation.DelayFadeIn</include>
                 </control>
-                
+
 
                 <!-- Content List -->
                 <control type="list" id="9501">

--- a/1080i/DialogNotification.xml
+++ b/1080i/DialogNotification.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <window id="107">
-    
+
 
     <controls>
 
@@ -13,7 +13,7 @@
             <height>100</height>
             <include>Animation.FadeIn.Slide</include>
             <include>Animation.FadeOut</include>
-    
+
             <control type="image">
                 <description>background image</description>
                 <posx>0</posx>
@@ -26,7 +26,7 @@
             </control>
 
             <control type="group">
-                
+
                 <control type="image" id="400">
                     <left>20</left>
                     <centertop>50%</centertop>
@@ -36,7 +36,7 @@
                     <colordiffuse>$VAR[OSDPanelWhite70-Kaitoast]</colordiffuse>
                     <texture>kaitoast/info.png</texture>
                 </control>
-                
+
                 <control type="label" id="401">
                     <left>104</left>
                     <width>536</width>
@@ -58,7 +58,7 @@
 
             </control>
         </control>
-        
+
     </controls>
 
 </window>

--- a/1080i/DialogNumeric.xml
+++ b/1080i/DialogNumeric.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="109">
     <defaultcontrol always="true">21</defaultcontrol>
-    
+
     <zorder>10</zorder>
 
     <coordinates>

--- a/1080i/DialogPVRChannelManager.xml
+++ b/1080i/DialogPVRChannelManager.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window id="605">
     <defaultcontrol always="true">20</defaultcontrol>
-    
+
     <onunload>ClearProperty(Focus)</onunload>
     <controls>
         <include>GlobalOverlay</include>
@@ -11,16 +11,16 @@
             <width>1290</width>
             <height>1006</height>
             <include>DefDialogInfoPanel</include>
-                        
+
             <control type="label">
                 <include>DefDialogHeader</include>
                 <label>$LOCALIZE[19199] • $LOCALIZE[19023]</label>>
-            </control>      
+            </control>
 
             <control type="group" id="8000">
                 <posx>30</posx>
                 <posy>90</posy>
-                <width>1230</width>             
+                <width>1230</width>
                 <control type="list" id="20">
                     <posx>0</posx>
                     <posy>0</posy>
@@ -197,7 +197,7 @@
                     </control>
                 </control>
             </control>
-        
+
             <control type="grouplist" id="8003">
                 <centerleft>50%</centerleft>
                 <bottom>30</bottom>
@@ -230,7 +230,7 @@
                     <texturenofocus colordiffuse="Black12" border="5">common/box.png</texturenofocus>
                     <include>DefDialogButtons</include>
                 </control>
-           
+
             </control>
 
         </control>

--- a/1080i/DialogPVRChannelsOSD.xml
+++ b/1080i/DialogPVRChannelsOSD.xml
@@ -2,9 +2,9 @@
 <!-- Foundation -->
 <window>
     <defaultcontrol always="true">11</defaultcontrol>
-    
+
     <controls>
-    
+
         <control type="group">
             <visible>!Window.IsActive(DialogPVRGuideInfo.xml)</visible>
             <animation effect="slide" start="-668" end="0" time="150" tween="quadratic">Visible</animation>
@@ -22,7 +22,7 @@
             </control>
             <control type="image">
                 <posx>530</posx>
-                <posy>-4</posy>  
+                <posy>-4</posy>
                 <width>128</width>
                 <height>128</height>
                 <texture>special://skin/extras/icons/livetv.png</texture>
@@ -67,7 +67,7 @@
                     </control>
                     <control type="image">
                         <posx>22</posx>
-                        <posy>12</posy>  
+                        <posy>12</posy>
                         <width>85</width>
                         <height>85</height>
                         <texture>$INFO[ListItem.Thumb]</texture>
@@ -134,7 +134,7 @@
                     </control>
                     <control type="image">
                         <posx>22</posx>
-                        <posy>12</posy>  
+                        <posy>12</posy>
                         <width>85</width>
                         <height>85</height>
                         <texture>$INFO[ListItem.Thumb]</texture>
@@ -184,7 +184,7 @@
                         <selectedcolor>Selected</selectedcolor>
                     </control>
                 </focusedlayout>
-            
+
             </control>
         </control>
     </controls>

--- a/1080i/DialogPVRGroupManager.xml
+++ b/1080i/DialogPVRGroupManager.xml
@@ -7,12 +7,12 @@
         <control type="group">
             <width>1350</width>
             <include>DefDialogInfoPanel</include>
-                        
+
             <control type="label">
                 <include>DefDialogHeader</include>
                 <label>$LOCALIZE[19143]</label>
             </control>
-            
+
             <control type="group">
                 <description>Group list</description>
                 <posx>30</posx>
@@ -79,9 +79,9 @@
                         </control>
                     </focusedlayout>
                 </control>
-          
+
             </control>
-            
+
             <control type="group">
                 <description>Group list</description>
                 <posx>460</posx>
@@ -149,7 +149,7 @@
                     </focusedlayout>
                 </control>
             </control>
-            
+
             <control type="group">
                 <description>Group list</description>
                 <posx>920</posx>
@@ -217,7 +217,7 @@
                     </focusedlayout>
                 </control>
             </control>
-            
+
             <control type="grouplist" id="9000">
                 <centerleft>50%</centerleft>
                 <bottom>30</bottom>

--- a/1080i/DialogPVRGuideOSD.xml
+++ b/1080i/DialogPVRGuideOSD.xml
@@ -2,9 +2,9 @@
 <!-- Foundation -->
 <window>
     <defaultcontrol always="true">11</defaultcontrol>
-    
+
     <controls>
-    
+
         <control type="group">
             <visible>!Window.IsActive(DialogPVRGuideInfo.xml)</visible>
             <animation effect="slide" start="-668" end="0" time="150" tween="quadratic">Visible</animation>
@@ -22,7 +22,7 @@
             </control>
             <control type="image">
                 <posx>530</posx>
-                <posy>-4</posy>  
+                <posy>-4</posy>
                 <width>128</width>
                 <height>128</height>
                 <texture>special://skin/extras/icons/livetv.png</texture>
@@ -31,7 +31,7 @@
             </control>
             <control type="image">
                 <posx>498</posx>
-                <posy>28</posy>  
+                <posy>28</posy>
                 <width>128</width>
                 <height>64</height>
                 <aspectratio align="right">keep</aspectratio>
@@ -150,7 +150,7 @@
                         <label>$INFO[ListItem.StartTime,,   ]</label>
                     </control>
                 </focusedlayout>
-            
+
             </control>
         </control>
     </controls>

--- a/1080i/DialogPVRGuideSearch.xml
+++ b/1080i/DialogPVRGuideSearch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window id="605">
     <defaultcontrol always="true">20</defaultcontrol>
-    
+
     <onunload>ClearProperty(Focus)</onunload>
     <controls>
         <include>GlobalOverlay</include>
@@ -11,11 +11,11 @@
             <width>1290</width>
             <height>1006</height>
             <include>DefDialogInfoPanel</include>
-                        
+
             <control type="label">
                 <include>DefDialogHeader</include>
                 <label>$LOCALIZE[19142]</label>
-            </control>      
+            </control>
 
             <control type="group" id="8000">
                 <posx>30</posx>
@@ -132,9 +132,9 @@
                         <label>19125</label>
                     </control>
                 </control>
-            
+
             </control>
-        
+
             <control type="grouplist" id="8003">
                 <centerleft>50%</centerleft>
                 <bottom>30</bottom>
@@ -167,7 +167,7 @@
                     <texturenofocus colordiffuse="Black12" border="5">common/box.png</texturenofocus>
                     <include>DefDialogButtons</include>
                 </control>
-           
+
             </control>
 
         </control>

--- a/1080i/DialogPVRInfo.xml
+++ b/1080i/DialogPVRInfo.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="2003">
     <defaultcontrol always="true">9000</defaultcontrol>
-    
+
 
     <controls>
         <control type="image">
@@ -30,14 +30,14 @@
                 <control type="group" description="Poster">
                     <left>SidePad</left>
                     <top>PosterPad</top>
-               
+
                     <control type="image">
                         <centertop>PosterH</centertop>
                         <width>PosterH</width>
                         <height>48</height>
                         <aspectratio>stretch</aspectratio>
                         <texture>diffuse/shadowspot.png</texture>
-                        
+
                     </control>
                     <control type="image">
                         <width>PosterH</width>
@@ -83,7 +83,7 @@
                     <onup condition="Control.IsVisible(9501)">9501</onup>
                     <orientation>horizontal</orientation>
 
-                    
+
                     <control type="button" id="4">
                         <align>center</align>
                         <width>260</width>
@@ -120,7 +120,7 @@
 
                 </control>
 
-                
+
 
                 <!-- Info -->
                 <control type="group">
@@ -150,7 +150,7 @@
                                 <aligny>center</aligny>
                             </control>
                         </control>
-                        
+
                         <control type="group">
                             <height>36</height>
                             <control type="label">
@@ -252,7 +252,7 @@
                     </control>
                 </control>
 
-               
+
             </control>
         </control>
     </controls>

--- a/1080i/DialogPictureInfo.xml
+++ b/1080i/DialogPictureInfo.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="139">
     <defaultcontrol always="true">5</defaultcontrol>
-    
+
 
     <controls>
 
@@ -14,7 +14,7 @@
             <width>900</width>
             <height>654</height>
             <include>DefDialogInfoPanel</include>
-       
+
 
             <control type="label">
                 <description>heading</description>

--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -5,7 +5,7 @@
     <visible>Window.IsActive(fullscreenvideo) + !Window.IsActive(script.pseudotv.TVOverlay.xml) + !Window.IsActive(script.pseudotv.live.TVOverlay.xml)</visible>
     <visible>Window.IsActive(fullscreenvideo) + !Window.IsActive(script.pseudotv.TVOverlay.xml) + !Window.IsActive(script.pseudotv.live.TVOverlay.xml)</visible>
     <visible>Window.IsActive(fullscreenvideo) + !Window.IsActive(script.pseudotv.TVOverlay.xml) + !Window.IsActive(script.pseudotv.live.TVOverlay.xml)</visible>
-    
+
     <visible>[VideoPlayer.IsFullscreen] + [Window.IsVisible(videoosd) | Window.IsVisible(fullscreeninfo) | Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding | Player.ShowInfo | !IsEmpty(Window(home).Property(osdshowinfo))]</visible>
     <zorder>0</zorder>
     <controls>
@@ -56,7 +56,7 @@
                         <texture>$VAR[PlayerPoster]</texture>
                         <visible>!IsEmpty(Player.Art(tvshow.poster)) | !IsEmpty(Player.Art(poster))</visible>
                     </control>
-                    
+
                     <control type="image">
                         <width>260</width>
                         <height>260</height>
@@ -64,25 +64,25 @@
                         <texture>$INFO[Player.Art(thumb)]</texture>
                         <visible>VideoPlayer.Content(LiveTV) + !IsEmpty(Player.Art(thumb))</visible>
                     </control>
-                    
+
                     <control type="group">
                         <left>290</left>
                         <visible>VideoPlayer.Content(LiveTV) + !IsEmpty(Player.Art(thumb))</visible>
                         <include>OSDInfoContent</include>
                     </control>
-                    
+
                     <control type="group">
                         <left>203</left>
                         <visible>!IsEmpty(Player.Art(tvshow.poster)) | !IsEmpty(Player.Art(poster))</visible>
                         <include>OSDInfoContent</include>
                     </control>
-                    
+
                     <control type="group">
                         <left>0</left>
                         <visible>IsEmpty(Player.Art(tvshow.poster)) + IsEmpty(Player.Art(poster)) + [!VideoPlayer.Content(LiveTV) | IsEmpty(Player.Art(thumb))]</visible>
                         <include>OSDInfoContent</include>
                     </control>
-                
+
                 </control>
             </control>
             <control type="group">
@@ -94,7 +94,7 @@
                 <top>110r</top>
                 <bottom>0</bottom>
                 <width>100%</width>
-                
+
                 <control type="group">
                     <left>SidePad</left>
                     <right>SidePad</right>
@@ -128,7 +128,7 @@
                         <textcolor>$VAR[OSDPanelWhite70]</textcolor>
                         <label>$INFO[Player.Time]$INFO[Player.Duration,  /  ,]</label>
                     </control>
-          
+
                     <control type="progress" description="cache">
                         <description>Progress Bar</description>
                         <width>100%</width>
@@ -158,7 +158,7 @@
                     </control>
                 </control>
             </control>
-        
+
         </control>
         <!-- Clock -->
         <include>Furniture_OSDClock</include>

--- a/1080i/DialogSelect.xml
+++ b/1080i/DialogSelect.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="2000">
     <defaultcontrol always="true">3</defaultcontrol>
-    
+
     <controls>
 
         <include>GlobalOverlay</include>
@@ -190,7 +190,7 @@
                             <texture border="5" colordiffuse="$VAR[ColorHighlight]">common/white.png</texture>
                         </control>
 
-                   
+
                         <control type="image">
                             <posx>32</posx>
                             <posy>12</posy>
@@ -284,7 +284,7 @@
                 <aspectratio align="center" aligny="bottom">keep</aspectratio>
                 <visible>Control.IsVisible(6)</visible>
             </control>
-            
+
             <control type="image">
                 <posx>705</posx>
                 <top>120</top>

--- a/1080i/DialogSettings.xml
+++ b/1080i/DialogSettings.xml
@@ -12,7 +12,7 @@
             <height>866</height>
             <width>1100</width>
             <include>DefDialogInfoPanel</include>
-            
+
             <control type="label" id="2">
                 <description>Header Label</description>
                 <centerleft>50%</centerleft>
@@ -21,7 +21,7 @@
                 <posy>15</posy>
                 <font>MediumBold</font>
             </control>
-  
+
             <control type="grouplist" id="5">
                 <description>Control Area</description>
                 <left>15</left>
@@ -91,7 +91,7 @@
             <control type="image" id="11">
                 <visible>false</visible>
             </control>
-            
+
             <control type="edit" id="12">
                 <description>Default Button</description>
                 <align>left</align>

--- a/1080i/DialogSlider.xml
+++ b/1080i/DialogSlider.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="145">
     <defaultcontrol always="true">11</defaultcontrol>
-    
+
     <zorder>5</zorder>
 
     <controls>
@@ -21,7 +21,7 @@
                 <animation effect="fade" start="100" end="90" condition="Skin.HasSetting(osd.usetheme)">Conditional</animation>
                 <texture border="16">common/rounded-shadow8.png</texture>
             </control>
-            
+
             <control type="label" id="10">
                 <description>Heading</description>
                 <top>20</top>

--- a/1080i/DialogSubtitles.xml
+++ b/1080i/DialogSubtitles.xml
@@ -6,7 +6,7 @@
             <width>1630</width>
             <height>798</height>
             <include>DefDialogInfoPanel</include>
-            
+
             <!-- Header -->
             <control type="label" id="100">
                 <description>Header Label</description>
@@ -17,7 +17,7 @@
                 <posy>15</posy>
                 <font>MediumBold</font>
             </control>
-            
+
             <!-- Header Image -->
             <control type="image" id="110">
                 <posx>15</posx>
@@ -26,11 +26,11 @@
                 <height>60</height>
                 <aspectratio align="left" aligny="top">keep</aspectratio>
             </control>
-            
-            
-            
 
-            
+
+
+
+
             <!-- Subs List -->
             <control type="list" id="120">
                 <left>15</left>
@@ -169,12 +169,12 @@
                         <font>Small</font>
                         <scroll>true</scroll>
                     </control>
-         
+
                 </focusedlayout>
 
             </control>
-            
-            
+
+
             <!-- Search Labels -->
             <control type="label" id="140">
                 <description>Content Picker label</description>
@@ -185,7 +185,7 @@
                 <textcolor>Black30</textcolor>
                 <visible>false</visible>
             </control>
-            
+
             <control type="label">
                 <description>Content Picker label</description>
                 <left>45</left>
@@ -196,7 +196,7 @@
                 <textcolor>Black70</textcolor>
                 <label>$INFO[Control.GetLabel(140),,   ]$INFO[Player.FileName]</label>
             </control>
-            
+
             <!-- Manual Search -->
             <control type="button" id="160">
                 <posx>1130</posx>
@@ -212,7 +212,7 @@
                 <texturefocus border="5" colordiffuse="$VAR[ColorHighlight]">common/box.png</texturefocus>
                 <texturenofocus border="5" colordiffuse="Black12">common/box.png</texturenofocus>
             </control>
-            
+
             <!-- Providers -->
             <control type="list" id="150">
                 <description>Button Area</description>
@@ -277,15 +277,15 @@
                         <selectedcolor>Highlight2</selectedcolor>
                         <visible>Control.HasFocus(150)</visible>
                     </control>
-                    
+
                 </focusedlayout>
             </control>
-            
-            
-            
-                
-            
-            
+
+
+
+
+
+
         </control>
     </controls>
 </window>

--- a/1080i/DialogTextViewer.xml
+++ b/1080i/DialogTextViewer.xml
@@ -12,9 +12,9 @@
             <posy>83</posy>
             <width>1500</width>
             <height>950</height>
-            
+
             <include>DefDialogInfoPanel</include>
-            
+
             <control type="label" id="1">
                 <description>header label</description>
                 <left>30</left>

--- a/1080i/DialogVideoInfo.xml
+++ b/1080i/DialogVideoInfo.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="2003">
     <defaultcontrol always="true">8</defaultcontrol>
-    
+
     <zorder>0</zorder>
     <onload condition="System.HasAddon(script.videoextras)">RunScript(script.videoextras,check,"$INFO[ListItem.FilenameAndPath]")</onload>
     <onload>ClearProperty(content)</onload>
@@ -29,7 +29,7 @@
                 <animation effect="slide" start="0" end="1920" time="300" tween="quadratic" easing="in">WindowClose</animation>
                 <animation effect="slide" start="1920" end="0" delay="0" time="300" tween="quadratic" easing="out">Visible</animation>
                 <animation effect="slide" start="0" end="1920" time="300" tween="quadratic" easing="in">Hidden</animation>
-          
+
                 <!-- Arrows -->
                 <control type="group">
                     <include>Animation.DelayFadeIn</include>
@@ -117,15 +117,15 @@
                         <onclick condition="!Control.IsVisible(50)">SendClick(2003,5)</onclick>
                         <onclick>ClearProperty(content)</onclick>
                         <onclick>SetFocus(51)</onclick>
-                        <visible>!substring(Container.FolderPath,plugin://,left)</visible>             
+                        <visible>!substring(Container.FolderPath,plugin://,left)</visible>
                     </control>
-                    
+
                     <control type="button" id="9011">
                         <include>DefInfoButtons</include>
                         <label>20339</label>
                         <onclick condition="Control.IsVisible(50)">SendClick(2003,5)</onclick>
                         <onclick>SetProperty(content,3)</onclick>
-                        <onclick>SetFocus(9501)</onclick>        
+                        <onclick>SetFocus(9501)</onclick>
                         <visible>Container.Content(movies)</visible>
                         <visible>!IsEmpty(ListItem.Director)</visible>
                     </control>
@@ -135,7 +135,7 @@
                         <label>31206</label>
                         <onclick condition="Control.IsVisible(50)">SendClick(2003,5)</onclick>
                         <onclick>SetProperty(content,2)</onclick>
-                        <onclick>SetFocus(9501)</onclick>     
+                        <onclick>SetFocus(9501)</onclick>
                         <visible>Container.Content(movies)</visible>
                     </control>
 
@@ -245,7 +245,7 @@
                         <width>410</width>
                         <height>410</height>
                         <texture>$INFO[ListItem.Art(discart)]</texture>
-                    </control>    
+                    </control>
                     <control type="grouplist">
                         <left>30</left>
                         <right>30</right>
@@ -269,7 +269,7 @@
                             </control>
                         </control>
                         <control type="group">
-                    
+
                             <height>36</height>
                             <control type="label">
                                 <width>100%</width>
@@ -290,7 +290,7 @@
                             </control>
                         </control>
                         <control type="group">
-                    
+
                             <height>36</height>
                             <control type="label">
                                 <width>100%</width>
@@ -311,7 +311,7 @@
                             </control>
                         </control>
                         <control type="group">
-                    
+
                             <height>36</height>
                             <control type="label">
                                 <width>100%</width>
@@ -332,7 +332,7 @@
                             </control>
                         </control>
                         <control type="group">
-                    
+
                             <height>36</height>
                             <control type="label">
                                 <width>100%</width>
@@ -353,7 +353,7 @@
                             </control>
                         </control>
                         <control type="group">
-                    
+
                             <height>36</height>
                             <control type="label">
                                 <width>100%</width>
@@ -374,7 +374,7 @@
                             </control>
                         </control>
                         <control type="group">
-                    
+
                             <height>36</height>
                             <control type="label">
                                 <width>100%</width>
@@ -395,7 +395,7 @@
                             </control>
                         </control>
                         <control type="group">
-                    
+
                             <height>36</height>
                             <control type="label">
                                 <width>100%</width>
@@ -416,7 +416,7 @@
                             </control>
                         </control>
                         <control type="group">
-                    
+
                             <height>36</height>
                             <control type="label">
                                 <width>100%</width>
@@ -540,22 +540,22 @@
                             <aligny>center</aligny>
                         </control>
                         <control type="textbox" id="4">
-                    
+
                             <width>100%</width>
                             <height>94</height>
                             <font>Tiny</font>
                             <textcolor>Dark2</textcolor>
                             <align>justify</align>
                         </control>
-                        
+
                     </control>
                 </control>
-                
+
                 <control type="group">
                     <include>Animation.FadeIn.Slide</include>
                     <visible>Control.IsVisible(50)</visible>
                     <control type="list" id="50">
-             
+
                         <bottom>80</bottom>
                         <left>530</left>
                         <width>1320</width>
@@ -678,7 +678,7 @@
                     <visible>!IsEmpty(Window.Property(content)) + Container(9501).IsUpdating + !Control.IsVisible(50)</visible>
                     <include>Animation.FadeIn</include>
                     <include>Animation.FadeOut</include>
-              
+
                     <control type="image">
                         <description>Busy animation</description>
                         <centerleft>54</centerleft>
@@ -853,7 +853,7 @@
             <visible>Control.HasFocus(9601)</visible>
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
-            
+
             <control type="image" description="Background">
                 <include>Dimensions_Fullscreen</include>
                 <texture colordiffuse="Background">common/bg.jpg</texture>
@@ -879,8 +879,8 @@
             <visible>Control.HasFocus(9601)</visible>
             <include>Animation.FadeIn.Slide</include>
             <include>Animation.FadeOut</include>
-            
-            
+
+
             <control type="label">
                 <description>header label</description>
                 <left>60</left>
@@ -915,7 +915,7 @@
             <onback>9000</onback>
             <onclick>RunScript(script.extendedinfo,info=extendedactorinfo,name=$INFO[Container(50).ListItem.Label])</onclick>
         </control>
-        
+
 
     </controls>
 

--- a/1080i/DialogVolumeBar.xml
+++ b/1080i/DialogVolumeBar.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <window id="104">
-    
+
 
     <controls>
 
-        <control type="group">  
+        <control type="group">
             <visible>!Player.Muted</visible>
             <control type="group">
                 <right>72</right>
@@ -27,7 +27,7 @@
 
                 <control type="group">
                     <visible>!player.passthrough</visible>
-                    
+
                     <control type="image">
                         <left>24</left>
                         <centertop>50%</centertop>
@@ -37,7 +37,7 @@
                         <texture colordiffuse="Dark1">buttons/volume.png</texture>
                         <visible>!Player.Muted</visible>
                     </control>
-                    
+
                     <control type="image">
                         <left>24</left>
                         <centertop>50%</centertop>
@@ -47,7 +47,7 @@
                         <texture colordiffuse="Dark1">buttons/mute.png</texture>
                         <visible>Player.Muted</visible>
                     </control>
-                    
+
                     <control type="label">
                         <left>104</left>
                         <top>24</top>
@@ -57,7 +57,7 @@
                         <label>$LOCALIZE[13376]$INFO[Player.Volume,  ,]</label>
                         <textcolor>Dark1</textcolor>
                     </control>
-                    
+
                     <control type="label">
                         <align>right</align>
                         <right>24</right>
@@ -116,7 +116,7 @@
 
                 <control type="group">
                     <visible>!player.passthrough</visible>
-                    
+
                     <control type="image">
                         <left>24</left>
                         <centertop>50%</centertop>
@@ -126,7 +126,7 @@
                         <texture colordiffuse="PanelWhite70">buttons/volume.png</texture>
                         <visible>!Player.Muted</visible>
                     </control>
-                    
+
                     <control type="image">
                         <left>24</left>
                         <centertop>50%</centertop>
@@ -136,7 +136,7 @@
                         <texture colordiffuse="PanelWhite70">buttons/mute.png</texture>
                         <visible>Player.Muted</visible>
                     </control>
-                    
+
                     <control type="label">
                         <left>104</left>
                         <top>24</top>
@@ -146,7 +146,7 @@
                         <label>$LOCALIZE[13376]$INFO[Player.Volume,  ,]</label>
                         <textcolor>PanelWhite70</textcolor>
                     </control>
-                    
+
                     <control type="label">
                         <align>right</align>
                         <right>24</right>
@@ -186,7 +186,7 @@
                 </control>
 
             </control>
-            
+
             <control type="progress" id="1">
                 <description>progress control</description>
                 <left>104</left>

--- a/1080i/EventLog.xml
+++ b/1080i/EventLog.xml
@@ -20,7 +20,7 @@
             <include>Def9000Background</include>
             <control type="grouplist" id="9000">
                 <include>Def9000GroupList</include>
-                
+
                 <control type="button" id="21">
                     <include>DefContextButton</include>
                     <align>left</align>

--- a/1080i/FileBrowser.xml
+++ b/1080i/FileBrowser.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="126">
     <defaultcontrol always="true">450</defaultcontrol>
-    
+
 
     <controls>
 
@@ -233,7 +233,7 @@
 
                 <control type="button" id="413">
                     <description>Ok</description>
-                    
+
                     <label>186</label>
                     <include>DefDialogButtons</include>
                 </control>
@@ -262,7 +262,7 @@
                 <texture fallback="DefaultAddonNone.png">$INFO[Container(450).ListItem.Icon]</texture>
                 <aspectratio align="center" aligny="bottom">keep</aspectratio>
             </control>
-            
+
             <control type="image">
                 <posx>705</posx>
                 <top>120</top>

--- a/1080i/FileManager.xml
+++ b/1080i/FileManager.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="3">
     <defaultcontrol always="true">20</defaultcontrol>
-    
+
 
     <controls>
 
@@ -11,7 +11,7 @@
         <include>Furniture_Clock</include>
         <include>Furniture_NowPlaying</include>
         <include>Furniture_Weather</include>
-        
+
         <control type="group">
             <include>Animation.Common</include>
             <control type="group">
@@ -49,7 +49,7 @@
 
                     <itemlayout height="69" width="840">
 
-                        
+
 
                         <control type="label">
                             <posx>30</posx>
@@ -110,14 +110,14 @@
                 </control>
 
             </control>
-            
+
             <control type="group">
                 <description>Right panel</description>
                 <right>SidePad</right>
                 <top>PosterPad</top>
                 <height>640</height>
                 <width>870</width>
-            
+
                 <control type="image">
                     <width>100%</width>
                     <height>100%</height>
@@ -147,7 +147,7 @@
 
                     <itemlayout height="69" width="840">
 
-                        
+
 
                         <control type="label">
                             <posx>30</posx>
@@ -208,9 +208,9 @@
                 </control>
 
             </control>
-            
+
         </control>
-        
+
     </controls>
 
 </window>

--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -17,7 +17,7 @@
             <filename>RobotoCondensed-Light.ttf</filename>
             <size>48</size>
         </font>
- 
+
         <font>
             <name>EpisodeNumber</name>
             <filename>RobotoCondensed-Bold.ttf</filename>
@@ -33,7 +33,7 @@
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>38</size>
         </font>
-        
+
         <font>
             <name>Small</name>
             <filename>RobotoCondensed-Regular.ttf</filename>
@@ -44,8 +44,8 @@
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>32</size>
         </font>
-        
-      
+
+
         <font>
             <name>Tiny</name>
             <filename>RobotoCondensed-Regular.ttf</filename>
@@ -67,7 +67,7 @@
             <filename>RobotoCondensed-Regular.ttf</filename>
             <size>24</size>
         </font>
-        
+
         <font>
             <name>Flag</name>
             <style>uppercase</style>
@@ -98,14 +98,14 @@
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>26</size>
         </font>
-        
+
         <font>
             <name>WidgetSelector</name>
             <style>uppercase</style>
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>22</size>
         </font>
- 
+
         <!-- Required for system -->
         <font>
             <name>font13</name>
@@ -116,7 +116,7 @@
             <name>Clock</name>
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>130</size>
-        </font>        
+        </font>
 
     </fontset>
 
@@ -153,7 +153,7 @@
             <filename>arial.ttf</filename>
             <size>38</size>
         </font>
-        
+
         <font>
             <name>Small</name>
             <filename>arial.ttf</filename>
@@ -164,8 +164,8 @@
             <filename>arial.ttf</filename>
             <size>32</size>
         </font>
-        
-      
+
+
         <font>
             <name>Tiny</name>
             <filename>arial.ttf</filename>
@@ -187,7 +187,7 @@
             <filename>arial.ttf</filename>
             <size>24</size>
         </font>
-        
+
         <font>
             <name>Flag</name>
             <style>uppercase</style>
@@ -218,16 +218,16 @@
             <filename>arial.ttf</filename>
             <size>26</size>
         </font>
-        
+
         <font>
             <name>WidgetSelector</name>
             <style>uppercase</style>
             <filename>arial.ttf</filename>
             <size>22</size>
         </font>
-        
-      
-        
+
+
+
         <!-- Required for system -->
         <font>
             <name>font13</name>
@@ -238,7 +238,7 @@
             <name>Clock</name>
             <filename>arial.ttf</filename>
             <size>130</size>
-        </font>         
+        </font>
 
     </fontset>
 
@@ -275,7 +275,7 @@
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>38</size>
         </font>
-        
+
         <font>
             <name>Small</name>
             <filename>RobotoCondensed-Regular.ttf</filename>
@@ -286,8 +286,8 @@
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>34</size>
         </font>
-        
-      
+
+
         <font>
             <name>Tiny</name>
             <filename>RobotoCondensed-Regular.ttf</filename>
@@ -310,7 +310,7 @@
             <filename>RobotoCondensed-Regular.ttf</filename>
             <size>28</size>
         </font>
-        
+
         <font>
             <name>Flag</name>
             <style>uppercase</style>
@@ -341,14 +341,14 @@
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>26</size>
         </font>
-        
+
         <font>
             <name>WidgetSelector</name>
             <style>uppercase</style>
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>22</size>
         </font>
-       
+
         <!-- Required for system -->
         <font>
             <name>font13</name>
@@ -359,10 +359,10 @@
             <name>Clock</name>
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>130</size>
-        </font>          
+        </font>
 
     </fontset>
-    
-    
-    
+
+
+
 </fonts>

--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -2,15 +2,15 @@
 <!-- Foundation -->
 <window id="0">
     <defaultcontrol always="true">300</defaultcontrol>
-    
+
     <onload>RunScript(script.favourites)</onload>
     <onload>RunScript(script.skinshortcuts,type=buildxml&amp;mainmenuID=300&amp;group=mainmenu|x1111|x1112|x1113|x1114|x1115|x1116|x1117|x1118|x1119)</onload>
-    
+
     <controls>
         <include>GlobalBackground</include>
-        
+
         <include condition="Skin.HasSetting(home.vertical)">HomeVerticalMenu</include>
-        
+
         <include condition="!Skin.HasSetting(home.vertical)">HomeHeader</include>
         <include condition="!Skin.HasSetting(home.vertical)">HomeNextRecording</include>
         <include condition="!Skin.HasSetting(home.vertical)">HomeWeatherWidget</include>
@@ -20,7 +20,7 @@
         <include condition="!Skin.HasSetting(home.vertical) + !Skin.HasSetting(home.classicwidgets)">HomeRow</include>
         <include condition="!Skin.HasSetting(home.vertical) + !Skin.HasSetting(home.classicwidgets)">HomeWidgetInfo</include>
         <include condition="!Skin.HasSetting(home.vertical) + Skin.HasSetting(home.classicwidgets)">HomeClassicWidgets</include>
-        
+
         <include condition="!Skin.HasSetting(home.vertical) + Skin.HasSetting(home.submenu2) + !Skin.HasSetting(home.showicons)">HomeSubMenu2</include>
         <include condition="!Skin.HasSetting(home.vertical) + [!Skin.HasSetting(home.submenu2) | Skin.HasSetting(home.showicons)]">HomeSubMenu</include>
 

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -3,7 +3,7 @@
 <includes>
 
     <include file="Defaults.xml" />
-    
+
     <!-- Views -->
     <include file="View_50_List.xml" />
     <include file="View_51_BigWide.xml" />
@@ -18,8 +18,8 @@
     <include file="View_500_Thumbnails.xml" />
     <include file="View_503_Poster_Square.xml" />
     <include file="View_505_Wall_Square.xml" />
-    
-    
+
+
     <include file="Includes_Furniture.xml" />
     <include file="Includes_Home.xml" />
     <include file="Includes_GlobalSearch.xml" />
@@ -30,10 +30,10 @@
     <include file="Includes_Defs.xml" />
     <include file="Includes_PVR.xml" />
     <include file="Includes_OSD.xml" />
-    
+
     <!-- Skin Shortcuts -->
     <include file="script-skinshortcuts-includes.xml"/>
-    
+
 
     <include name="HiddenButton">
         <posx>-20</posx>
@@ -107,7 +107,7 @@
         <value condition="Window.IsVisible(home) + !IsEmpty(Skin.String(weather.fanart.path)) + substring(Container(300).ListItem.Property(widget),Weather,left) + !Skin.HasSetting(home.dontshowfanart)">$INFO[Skin.String(weather.fanart.path)]$INFO[Window(Weather).Property(Current.FanartCode)]/</value>
         <value condition="Window.IsVisible(home) + !IsEmpty(Container(301).ListItem.Art(fanart)) + [!Skin.HasSetting(home.dontshowfanart) | Control.HasFocus(301)] + Control.IsVisible(301)">$INFO[Container(301).ListItem.Art(fanart)]</value>
         <value condition="Window.IsVisible(home) + !IsEmpty(Container(301).ListItem.Property(fanart)) + [!Skin.HasSetting(home.dontshowfanart) | Control.HasFocus(301)] + Control.IsVisible(301)">$INFO[Container(301).ListItem.Property(fanart)]</value>
-        
+
         <value condition="Window.IsVisible(home) + StringCompare(Container(300).ListItem.Property(background),playlistBackground)">$INFO[Container(9988).ListItem.Art(fanart)]</value>
         <value condition="Window.IsVisible(home) + !IsEmpty(Container(300).ListItem.Property(Background))">$INFO[Container(300).ListItem.Property(Background)]</value>
         <value condition="Window.IsVisible(home) + !IsEmpty(Skin.String(home.slideshowpath)) + [substring(Container(300).ListItem.Property(widget),Weather,left) | IsEmpty(Container(300).ListItem.Property(widget)) | Container(301).IsUpdating |  Skin.HasSetting(home.dontshowfanart)]">$INFO[Skin.String(home.slideshowpath)]</value>
@@ -122,7 +122,7 @@
         <value condition="!IsEmpty(Skin.String(fanart.fallback))">$INFO[Skin.String(fanart.fallback)]</value>
         <value>common/null.png</value>
     </variable>
-    
+
     <include name="GlobalVideoWindow">
         <control type="image" description="Background">
             <include>Dimensions_Fullscreen</include>
@@ -204,7 +204,7 @@
             <include condition="!Skin.HasSetting(home.vertical)">Animation.FadeFromHome</include>
             <texture colordiffuse="FloorFade">common/floor.png</texture>
         </control>
-        
+
     </include>
     <include name="GlobalBackgroundExtended">
         <control type="image" description="Background">
@@ -230,7 +230,7 @@
             <include condition="!Skin.HasSetting(home.vertical)">Animation.FadeFromHome</include>
             <texture colordiffuse="FloorFade">common/floor.png</texture>
         </control>
-        
+
     </include>
 
 </includes>

--- a/1080i/Includes_Animations.xml
+++ b/1080i/Includes_Animations.xml
@@ -51,7 +51,7 @@
         </animation>
         <animation effect="fade" start="0" end="100" time="350" tween="cubic" easing="inout">WindowOpen</animation>
     </include>
-    
+
     <include name="Animation.FadeIn.Slide">
         <animation type="Visible" reversible="false">
             <effect type="fade" start="0" end="100" time="300" delay="150"/>
@@ -62,7 +62,7 @@
             <effect type="slide" start="0,-48" end="0" center="auto" tween="back" easing="out" time="450" delay="150"/>
         </animation>
     </include>
-    
+
     <include name="Animation.SlideUp">
         <animation type="Visible">
             <effect type="fade" start="0" end="100" time="250" delay="0" tween="cubic" easing="inout"/>
@@ -73,7 +73,7 @@
             <effect type="slide" start="0,48" end="0" center="auto" tween="back" easing="out" time="400" delay="0"/>
         </animation>
     </include>
-    
+
     <include name="Animation.FadeOut">
         <animation effect="fade" end="0" start="100" time="150">Hidden</animation>
         <animation effect="fade" end="0" start="100" time="150">WindowClose</animation>

--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -4,7 +4,7 @@
         <value condition="!IsEmpty(Skin.String(focuscolor.name))">$INFO[Skin.String(focuscolor.name)]</value>
         <value>Highlight</value>
     </variable>
-    
+
     <variable name="DefWidgetContent">
         <value condition="!IsEmpty(Container(300).ListItem.Property(widgetPath)) + Skin.HasSetting(NoPersistentWidgets)">$INFO[Container(300).ListItem.Property(widgetPath)]</value>
         <value condition="substring(Container(300).ListItem.Property(widget),Weather,left) + !IsEmpty(Skin.String(weather.fanart))">noop</value>
@@ -18,7 +18,7 @@
         <value condition="!IsEmpty(Container(300).ListItem.Property(widgetTarget))">$INFO[Container(300).ListItem.Property(widgetTarget)]</value>
         <value>videos</value>
     </variable>
-    
+
     <include name="DefNextAiredWidget">
         <item id="1">
             <onclick>ActivateWindow(Videos,$INFO[Window.Property(NextAired.1.Library)],return)</onclick>
@@ -172,8 +172,8 @@
             <onclick>$INFO[Window(Home).Property(favourite.7.path)]</onclick>
         </item>
     </include>
-    
-    
+
+
     <include name="DefWidgetSelector">
         <align>center</align>
         <aligny>center</aligny>
@@ -187,7 +187,7 @@
         <font>WidgetSelector</font>
         <texturefocus>noop</texturefocus>
     </include>
-    
+
     <include name="DefDialogButtons">
         <width>300</width>
         <font>Button</font>
@@ -206,7 +206,7 @@
         <alttexturenofocus colordiffuse="Dark4" border="5">common/box.png</alttexturenofocus>
         <alttexturefocus colordiffuse="$VAR[ColorHighlight]" border="5">common/box.png</alttexturefocus>
     </include>
-    
+
     <include name="DefDialogInfoPanel">
         <include>Animation.FadeIn.Slide</include>
         <include>Animation.FadeOut</include>
@@ -224,7 +224,7 @@
             <texture colordiffuse="White100" border="16">common/box.png</texture>
         </control>
     </include>
-    
+
     <include name="DefDialogInfoHeader">
         <left>30</left>
         <right>320</right>
@@ -235,7 +235,7 @@
         <textureradiofocus colordiffuse="Black70">buttons/radio-on.png</textureradiofocus>
         <textureradionofocus colordiffuse="Black30">buttons/radio-off.png</textureradionofocus>
     </include>
-    
+
     <include name="DefDialogHeader">
         <description>header label</description>
         <centerleft>50%</centerleft>
@@ -245,7 +245,7 @@
         <font>MediumBold</font>
         <textcolor>Black70</textcolor>
     </include>
-    
+
     <include name="DefDialogBackground">
         <include>Animation.ZoomIn</include>
         <centerleft>50%</centerleft>
@@ -258,7 +258,7 @@
             <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
         </control>
     </include>
-    
+
     <include name="DefDialogOK">
         <centerleft>50%</centerleft>
         <posy>360</posy>
@@ -298,9 +298,9 @@
             <height>300</height>
         </control>
 
-        
+
     </include>
-    
+
     <include name="DefPVRDialogButton">
         <width>600</width>
         <height>66</height>
@@ -309,7 +309,7 @@
         <radioposx>540</radioposx>
         <textcolor>Black70</textcolor>
     </include>
-    
+
     <include name="DefKeyboardKeys">
         <width>85</width>
         <height>75</height>
@@ -404,7 +404,7 @@
         <centerleft>50%</centerleft>
         <height>382</height>
         <width>466</width>
-        
+
         <control type="image">
             <description>background image</description>
             <posx>0</posx>
@@ -414,8 +414,8 @@
             <texture border="16" colordiffuse="White100">common/rounded-shadow8.png</texture>
         </control>
     </include>
-    
-    
+
+
     <include name="Def9000MusicSide">
         <control type="button" id="2">
             <description>View</description>
@@ -446,7 +446,7 @@
             <visible>Window.IsVisible(MyMusicSongs.xml)</visible>
             <visible>!stringcompare(Container.FolderPath,special://musicplaylists/)</visible>
         </control>
-        
+
         <control type="button" id="9098">
             <description>Now Playing</description>
             <include>DefContextButton</include>
@@ -456,9 +456,9 @@
             <visible>IntegerGreaterThan(Playlist.Length(music),1)</visible>
         </control>
 
-        
+
     </include>
-    
+
     <include name="DefDialogSelectManual6">
         <posx>738</posx>
         <posy>120</posy>
@@ -472,7 +472,7 @@
         <ondown>3</ondown>
         <font>Button</font>
         <textcolor>Black70</textcolor>
-        <texturefocus colordiffuse="$VAR[ColorHighlight]" border="5">common/box.png</texturefocus>    
+        <texturefocus colordiffuse="$VAR[ColorHighlight]" border="5">common/box.png</texturefocus>
     </include>
     <include name="DefDialogSelectManual3">
         <description>Manual</description>
@@ -491,7 +491,7 @@
         <texturefocus colordiffuse="$VAR[ColorHighlight]" border="5">common/box.png</texturefocus>
         <texturenofocus colordiffuse="Black12" border="5">common/box.png</texturenofocus>
     </include>
-    
+
     <include name="DefVideoInfoCastWithDirector">
         <top>171</top>
         <height>639</height>
@@ -500,7 +500,7 @@
         <top>100</top>
         <height>710</height>
     </include>
-    
+
     <include name="DefHomeRight520"><right>520</right></include>
     <include name="DefHomeRightSidePad"><right>SidePad</right></include>
 
@@ -509,20 +509,20 @@
         <value condition="stringcompare(Window.Property(content),2)">plugin://script.extendedinfo?info=similarmovies&amp;&amp;dbid=$INFO[ListItem.DBID]</value>
         <value>plugin://script.extendedinfo?info=directormovies&amp;&amp;director=$INFO[ListItem.Director]</value>
     </variable>
-    
+
     <variable name="DefDirectorWindowContent">
         <value condition="stringcompare(Window(1103).Property(content),1)">plugin://script.extendedinfo?info=studio&amp;&amp;studio=$INFO[Window(home).Property(ExtStudio)]</value>
         <value condition="stringcompare(Window(1103).Property(content),2)">plugin://script.extendedinfo?info=similarmovies&amp;&amp;dbid=$INFO[Window(home).Property(ExtDBID)]</value>
         <value>plugin://script.extendedinfo?info=directormovies&amp;&amp;director=$INFO[Window(home).Property(ExtDirector)]</value>
     </variable>
-    
+
     <variable name="DefMovieDBMoviesContent">
         <value condition="stringcompare(Window(1104).Property(content),1)">plugin://script.extendedinfo?info=topratedmovies</value>
         <value condition="stringcompare(Window(1104).Property(content),2)">plugin://script.extendedinfo?info=popularmovies</value>
         <value condition="stringcompare(Window(1104).Property(content),3)">plugin://script.extendedinfo?info=upcomingmovies</value>
         <value>plugin://script.extendedinfo?info=incinemamovies</value>
     </variable>
-    
+
     <variable name="DefMovieDBEpisodesContent">
         <value condition="stringcompare(Window(1105).Property(content),1)">plugin://script.extendedinfo?info=topratedtvshows</value>
         <value condition="stringcompare(Window(1105).Property(content),2)">plugin://script.extendedinfo?info=populartvshows</value>
@@ -586,7 +586,7 @@
             <aspectratio scalediffuse="false">scale</aspectratio>
             <texture diffuse="diffuse/wall.png" background="true" fallback="DefaultPicture.png">$INFO[ListItem.Icon]</texture>
         </control>
-     
+
         <control type="image">
             <left>10</left>
             <right>10</right>
@@ -798,7 +798,7 @@
                         <visible>Control.HasFocus(9500)</visible>
                     </control>
                 </control>
-                
+
                 <control type="group">
                     <control type="list" id="9501">
                         <description>Widget</description>
@@ -882,7 +882,7 @@
                         <content><include>$PARAM[list]</include></content>
                     </control>
                 </control>
-                
+
             </control>
             <control type="scrollbar" id="60">
                 <onback>9501</onback>

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -15,7 +15,7 @@
             <animation effect="fade" start="100" end="33" time="400" condition="!Control.HasFocus(60) + !Container.Scrolling">Conditional</animation>
         </control>
     </include>
-    
+
     <include name="Furniture_Scrollbar_Horizontal">
         <control type="scrollbar" id="60">
             <onback>50</onback>
@@ -32,8 +32,8 @@
             <animation effect="fade" start="100" end="33" time="400" condition="!Control.HasFocus(60) + !Container.Scrolling">Conditional</animation>
         </control>
     </include>
-    
-    
+
+
     <include name="Furniture_ButtonBack">
         <width>64</width>
         <height>64</height>
@@ -41,13 +41,13 @@
             <effect type="zoom" start="75" end="100" center="auto" time="200"/>
         </animation>
     </include>
-    
+
     <include name="Furniture_ButtonBack_Circle">
         <width>64</width>
         <height>64</height>
         <texture colordiffuse="Dark1">common/circle.png</texture>
     </include>
-    
+
     <!-- Flags -->
     <variable name="Flagstar1">
         <value condition="IntegerGreaterThan(ListItem.Rating,1)">star10</value>
@@ -99,7 +99,7 @@
         <value condition="IntegerGreaterThan(Container(9500).ListItem.Rating,8)">star5</value>
         <value>star0</value>
     </variable>
-    
+
     <variable name="HomeFlagstar1">
         <value condition="IntegerGreaterThan(Container(301).ListItem.Rating,1)">star10</value>
         <value condition="IntegerGreaterThan(Container(301).ListItem.Rating,0)">star5</value>
@@ -125,7 +125,7 @@
         <value condition="IntegerGreaterThan(Container(301).ListItem.Rating,8)">star5</value>
         <value>star0</value>
     </variable>
-    
+
     <!-- MusicFlags -->
     <variable name="MusicFlagstar5">
         <value condition="StringCompare(ListItem.StarRating,rating5.png)">star10</value>
@@ -157,7 +157,7 @@
         <value condition="StringCompare(ListItem.StarRating,rating1.png)">star10</value>
         <value>star0</value>
     </variable>
-    
+
     <!-- MusicOSDFlags -->
     <variable name="OSDMusicFlagstar5">
         <value condition="StringCompare(Player.StarRating,rating5.png)">star10</value>
@@ -247,7 +247,7 @@
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagicons) + !IsEmpty(ListItem.VideoResolution) + !substring(ListItem.Path,videodb://movies/sets,left)</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <height>64</height>
@@ -298,7 +298,7 @@
                 <textcolor>Dark1</textcolor>
                 <visible>Skin.HasSetting(furniture.numericrating)</visible>
             </control>
-            
+
             <control type="image">
                 <width>48</width>
                 <height>64</height>
@@ -351,9 +351,9 @@
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagicons) + !IsEmpty(ListItem.AudioChannels)</visible>
             </control>
-            
-            
-            
+
+
+
             <control type="image">
                 <width>48</width>
                 <height>64</height>
@@ -418,7 +418,7 @@
                 <texture colordiffuse="Dark1">flags/3D.png</texture>
                 <visible>ListItem.IsStereoscopic</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <centertop>50%</centertop>
@@ -440,7 +440,7 @@
                 <texture colordiffuse="Dark1">flags/dvd.png</texture>
                 <visible>substring(ListItem.FilenameAndPath,dvd) + !substring(ListItem.FilenameAndPath,hddvd)</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <centertop>50%</centertop>
@@ -448,7 +448,7 @@
                 <texture colordiffuse="Dark1">flags/imdb.png</texture>
                 <visible>!IsEmpty(ListItem.Top250)</visible>
             </control>
-            
+
         </control>
     </include>
     <include name="Furniture_Hub_Flags">
@@ -498,7 +498,7 @@
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagicons) + !IsEmpty(Container(9500).ListItem.VideoResolution)</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <height>64</height>
@@ -582,7 +582,7 @@
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagicons) + !IsEmpty(Container(9500).ListItem.AudioChannels)</visible>
             </control>
-            
+
             <control type="image">
                 <width>48</width>
                 <height>64</height>
@@ -617,7 +617,7 @@
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !IsEmpty(Container(9500).ListItem.AudioCodec)</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <height>64</height>
@@ -644,7 +644,7 @@
                 <texture colordiffuse="Dark1">flags/dvd.png</texture>
                 <visible>substring(Container(9500).ListItem.FilenameAndPath,dvd) + !substring(Container(9500).ListItem.FilenameAndPath,hddvd)</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <centertop>50%</centertop>
@@ -653,8 +653,8 @@
                 <visible>!IsEmpty(Container(9500).ListItem.Top250)</visible>
             </control>
 
-            
-            
+
+
         </control>
     </include>
     <include name="Furniture_Home_Flags">
@@ -705,7 +705,7 @@
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagicons) + !IsEmpty(Container(301).ListItem.VideoResolution)</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <height>64</height>
@@ -789,7 +789,7 @@
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagicons) + !IsEmpty(Container(301).ListItem.AudioChannels)</visible>
             </control>
-            
+
             <control type="image">
                 <width>48</width>
                 <height>64</height>
@@ -824,7 +824,7 @@
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !IsEmpty(Container(301).ListItem.AudioCodec)</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <height>64</height>
@@ -851,7 +851,7 @@
                 <texture colordiffuse="Dark1">flags/dvd.png</texture>
                 <visible>substring(Container(301).ListItem.FilenameAndPath,dvd) + !substring(Container(301).ListItem.FilenameAndPath,hddvd)</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <centertop>50%</centertop>
@@ -860,8 +860,8 @@
                 <visible>!IsEmpty(Container(301).ListItem.Top250)</visible>
             </control>
 
-            
-            
+
+
         </control>
     </include>
 
@@ -925,7 +925,7 @@
         <value condition="Control.HasFocus(181)">[COLOR=$VAR[ColorHighlight]]$INFO[Control.GetLabel(180)][/COLOR] $LOCALIZE[134]</value>
 
     </variable>
-    
+
     <variable name="MainHeaderLabel">
         <value condition="Skin.HasSetting(hide.busydialog) + Window.IsVisible(DialogBusy.xml)">$LOCALIZE[20186]...</value>
         <value condition="Window.IsVisible(Custom_SetCustomColor.xml)">$LOCALIZE[31238]</value>
@@ -944,7 +944,7 @@
         <value condition="Window.IsVisible(MyVideoNav.xml) + SubString(Container.FolderPath,videodb://tvshows/,Left) + Container.Content(episodes) + !IsEmpty(ListItem.TvShowTitle)">$INFO[ListItem.TvShowTitle]$INFO[Container.FolderName, - ,]</value>
         <value condition="Window.IsVisible(MyVideoNav.xml) + SubString(Container.FolderPath,videodb://tvshows/,Left)">$INFO[Container.FolderName]</value>
         <value condition="Window.IsVisible(MyVideoNav.xml) + !IsEmpty(Container.FolderName)">$INFO[Container.FolderName]</value>
-        <value condition="Window.IsVisible(MyVideoNav.xml)">$LOCALIZE[3]</value>                                                                          
+        <value condition="Window.IsVisible(MyVideoNav.xml)">$LOCALIZE[3]</value>
         <value condition="Window.IsVisible(MyPVRChannels.xml)">$LOCALIZE[19019]</value>
         <value condition="Window.IsVisible(MyPVRGuide.xml)">$LOCALIZE[4]</value>
         <value condition="Window.IsVisible(MyPVRRecordings.xml)">$LOCALIZE[19017]</value>
@@ -989,7 +989,7 @@
         <value condition="IsEmpty(Pvr.BackendChannels)">[COLOR=$VAR[ColorHighlight]]$INFO[Window(home).Property(Movies.Count)][/COLOR] $LOCALIZE[20342]  •  [COLOR=$VAR[ColorHighlight]]$INFO[Window(home).Property(Episodes.Count)][/COLOR] $LOCALIZE[20360]  •  [COLOR=$VAR[ColorHighlight]]$INFO[Window(home).Property(Music.SongsCount)][/COLOR] $LOCALIZE[134]</value>
         <value>[COLOR=$VAR[ColorHighlight]]$INFO[Window(home).Property(Movies.Count)][/COLOR] $LOCALIZE[20342]  •  [COLOR=$VAR[ColorHighlight]]$INFO[Window(home).Property(Episodes.Count)][/COLOR] $LOCALIZE[20360]  •  [COLOR=$VAR[ColorHighlight]]$INFO[Window(home).Property(Music.SongsCount)][/COLOR] $LOCALIZE[134]  •  [COLOR=$VAR[ColorHighlight]]$INFO[Pvr.BackendChannels][/COLOR] $LOCALIZE[19019]</value>
     </variable>
-  
+
     <include name="Furniture_Header">
         <control type="image" description="clearlogo">
             <include>Animation.FadeIn</include>
@@ -1110,7 +1110,7 @@
                 <width>120</width>
                 <label>$INFO[System.Time(xx)]</label>
                 <visible>!IsEmpty(System.Time(xx))</visible>
-            </control>  
+            </control>
             <control type="label">
                 <centertop>64</centertop>
                 <right>SidePad</right>
@@ -1130,9 +1130,9 @@
                 <visible>Skin.HasSetting(furniture.weather)</visible>
                 <label>[COLOR=$VAR[ColorHighlight]]$INFO[Weather.Temperature][/COLOR]  $INFO[Weather.Conditions]</label>
             </control>
-      
+
         </control>
-        
+
     </include>
 
     <include name="Furniture_Weather">
@@ -1277,7 +1277,7 @@
                     <aspectratio align="center">keep</aspectratio>
                     <visible>!IsEmpty(Player.Duration)</visible>
                 </control>
-              
+
             </control>
         </control>
     </include>
@@ -1355,5 +1355,5 @@
         </control>
     </include>
 
-    
+
 </includes>

--- a/1080i/Includes_GlobalSearch.xml
+++ b/1080i/Includes_GlobalSearch.xml
@@ -135,7 +135,7 @@
                     </control>
                 </focusedlayout>
             </control>
-        
+
             <control type="image">
                 <centertop>100</centertop>
                 <centerright>8</centerright>
@@ -149,7 +149,7 @@
         </control>
 
     </include>
-    
-    
-   
+
+
+
 </includes>

--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -4,7 +4,7 @@
         <!-- Header -->
         <control type="group">
             <visible>Skin.HasSetting(home.showheader)</visible>
-            
+
             <animation effect="slide" start="0" end="0,-250" time="150" condition="[!Skin.HasSetting(home.classicwidgets) + Control.HasFocus(301)]">Conditional</animation>
             <animation effect="slide" start="0" end="0,-250" time="150">WindowClose</animation>
             <animation effect="slide" end="0" start="0,-250" time="150">WindowOpen</animation>
@@ -38,7 +38,7 @@
             </control>
         </control>
     </include>
-    
+
     <include name="HomeNowPlaying">
         <!-- Next Recording -->
         <control type="group">
@@ -61,7 +61,7 @@
                 <texture border="16" colordiffuse="Background">common/rounded-shadow8.png</texture>
                 <animation effect="fade" start="100" end="90" condition="true">Conditional</animation>
             </control>
-            
+
             <control type="group">
                 <centertop>50%</centertop>
                 <centerleft>52</centerleft>
@@ -113,7 +113,7 @@
                     <aspectratio align="center">keep</aspectratio>
                     <visible>!IsEmpty(Player.Duration)</visible>
                 </control>
-              
+
             </control>
 
             <control type="group">
@@ -137,7 +137,7 @@
                     <label>$INFO[VideoPlayer.TvShowTitle,,  ]$INFO[MusicPlayer.Artist,,  ]$INFO[Player.Time]$INFO[Player.Duration, / ,]</label>
                 </control>
             </control>
-        </control>     
+        </control>
     </include>
 
     <include name="HomeNextRecording">
@@ -167,7 +167,7 @@
             </control>
 
             <control type="group">
-                
+
                 <control type="image">
                     <left>20</left>
                     <centertop>50%</centertop>
@@ -176,7 +176,7 @@
                     <aspectratio>keep</aspectratio>
                     <texture colordiffuse="Dark1">kaitoast/info.png</texture>
                 </control>
-                
+
                 <control type="label">
                     <left>104</left>
                     <top>22</top>
@@ -197,9 +197,9 @@
                 </control>
 
             </control>
-        </control>   
+        </control>
     </include>
-    
+
     <include name="HomeWeatherWidget">
         <!-- Weather Widget -->
         <control type="group">
@@ -319,7 +319,7 @@
                 <label>$LOCALIZE[31138]...</label>
                 <textcolor>Dark1</textcolor>
             </control>
-        </control> 
+        </control>
     </include>
     <include name="Home-Widget-Featured">
             <control type="wraplist" id="301">
@@ -355,7 +355,7 @@
             </animation>
             <include condition="Skin.HasSetting(NoPersistentWidgets)">Home-Widget-Featured</include>
             <include condition="!Skin.HasSetting(NoPersistentWidgets)">skinshortcuts-template-widget-featured</include>
-     
+
             <!-- Normal Widget -->
             <control type="group">
                 <visible>!Container(301).IsUpdating</visible>
@@ -455,7 +455,7 @@
                     <font>Flag</font>
                 </control>
             </control>
-            
+
             <!-- Square Widget -->
             <control type="group">
                 <visible>!Container(301).IsUpdating</visible>
@@ -495,7 +495,7 @@
                     <aspectratio scalediffuse="false">scale</aspectratio>
                     <texture diffuse="diffuse/widgetposter.png" fallback="DefaultAddonNone.png">$VAR[WidgetImage]</texture>
                 </control>
-      
+
                 <control type="label">
                     <left>359</left>
                     <top>5</top>
@@ -585,7 +585,7 @@
                     <aspectratio scalediffuse="false">scale</aspectratio>
                     <texture diffuse="diffuse/widgetposter.png" fallback="DefaultAddonNone.png">$VAR[WidgetThumbImageFeatured]</texture>
                 </control>
-      
+
                 <control type="label">
                     <left>611</left>
                     <top>5</top>
@@ -634,15 +634,15 @@
                     <font>Flag</font>
                 </control>
             </control>
-            
+
             <include>HomeWidgetUpdating</include>
         </control>
     </include>
-    
+
     <include name="HomeRow">
         <!-- Home Row -->
         <control type="group">
-            
+
             <animation effect="slide" start="0" end="0,250" time="150" condition="!Skin.HasSetting(home.classicwidgets) + [Control.HasFocus(301)]">Conditional</animation>
             <animation effect="slide" start="0" end="0,250" time="150">WindowClose</animation>
             <animation effect="slide" end="0" start="0,250" time="150">WindowOpen</animation>
@@ -695,7 +695,7 @@
                 <texture colordiffuse="Dark2" flipx="false">common/arrow-small-right.png</texture>
             </control>
             <control type="list" id="300">
-                
+
                 <include>Animation.FadeIn.Delay</include>
                 <include>Animation.FadeOut</include>
                 <description>Home Wraplist</description>
@@ -711,10 +711,10 @@
                 <include condition="Skin.HasSetting(home.showicons)">HomeContentIcon</include>
                 <include condition="!Skin.HasSetting(home.showicons)">HomeContentNoIcon</include>
             </control>
-        
+
         </control>
     </include>
-    
+
     <include name="HomeSubMenu">
         <!-- Sub Menu -->
         <control type="group">
@@ -722,7 +722,7 @@
                 <effect type="fade" start="0" end="100" time="250" delay="0" tween="cubic" easing="inout"/>
                 <effect type="slide" start="0,48" end="0" center="auto" tween="back" easing="out" time="400" delay="0"/>
             </animation>
-            
+
             <animation effect="fade" end="0" start="100" time="150" condition="!Control.HasFocus(302)" reversible="false">Conditional</animation>
             <include>Animation.FadeOut</include>
             <animation effect="slide" start="0" end="220" condition="Container(300).Position(1)">Conditional</animation>
@@ -730,13 +730,13 @@
             <animation effect="slide" start="0" end="660" condition="Container(300).Position(3)">Conditional</animation>
             <animation effect="slide" start="0" end="880" condition="Container(300).Position(4)">Conditional</animation>
             <animation effect="slide" start="0" end="1100" condition="Container(300).Position(5)">Conditional</animation>
-            
+
             <animation effect="slide" end="0,70" condition="!IntegerGreaterThan(Container(302).NumItems,5)">Conditional</animation>
             <animation effect="slide" end="0,70" condition="!IntegerGreaterThan(Container(302).NumItems,4)">Conditional</animation>
             <animation effect="slide" end="0,70" condition="!IntegerGreaterThan(Container(302).NumItems,3)">Conditional</animation>
             <animation effect="slide" end="0,70" condition="!IntegerGreaterThan(Container(302).NumItems,2)">Conditional</animation>
             <animation effect="slide" end="0,70" condition="!IntegerGreaterThan(Container(302).NumItems,1)">Conditional</animation>
-            
+
             <animation effect="slide" start="0" end="0,250" time="150" condition="Control.HasFocus(301)">Conditional</animation>
             <animation effect="slide" start="0" end="0,250" time="150">WindowClose</animation>
             <animation effect="slide" end="0" start="0,250" time="150">WindowOpen</animation>
@@ -744,7 +744,7 @@
             <centerleft>190</centerleft>
             <width>316</width>
             <height>452</height>
-           
+
             <control type="image">
                 <description>6 Option Menu</description>
                 <width>100%</width>
@@ -803,8 +803,8 @@
                 <scrolltime>200</scrolltime>
 
                 <itemlayout width="300" height="70">
-                   
-                  
+
+
                     <control type="label">
                         <align>center</align>
                         <aligny>center</aligny>
@@ -815,12 +815,12 @@
                         <include>DefContextButton</include>
                         <label>$INFO[ListItem.Label]</label>
                     </control>
-             
-                    
+
+
                 </itemlayout>
 
                 <focusedlayout width="300" height="70">
-                   
+
                     <control type="image">
                         <width>100%</width>
                         <height>100%</height>
@@ -836,16 +836,16 @@
                         <include>DefContextButton</include>
                         <label>$INFO[ListItem.Label]</label>
                     </control>
-                    
-                    
-             
+
+
+
                 </focusedlayout>
 
                 <content>
                     <include>skinshortcuts-submenu</include>
                 </content>
             </control>
-        
+
         </control>
     </include>
 
@@ -861,7 +861,7 @@
             <animation effect="slide" start="0" end="0,250" time="150">WindowClose</animation>
             <include>Animation.FadeOut</include>
             <control type="list" id="302">
-                
+
                 <description>Home Wraplist</description>
                 <left>SidePad</left>
                 <include condition="!Skin.HasSetting(furniture.clock)">DefHomeRight520</include>
@@ -920,7 +920,7 @@
                     <include>skinshortcuts-submenu</include>
                 </content>
             </control>
-        
+
         </control>
     </include>
 
@@ -1102,7 +1102,7 @@
                     </animation>
                     <bottom>190</bottom>
                     <height>297</height>
-                 
+
                     <control type="group">
                         <animation effect="fade" start="100" end="0" time="0" reversible="false" condition="![!substring(Container(300).ListItem.Property(widget),Weather,left) + [!IsEmpty(Container(300).ListItem.Property(widget)) | [IsEmpty(Container(300).ListItem.Property(widget)) + [IsEmpty(Container(300).ListItem.Property(Background)) + [IsEmpty(Skin.String(home.slideshowpath))]]]]]">Conditional</animation>
                         <animation effect="fade" start="0" end="100" time="0" delay="0" reversible="false" condition="!substring(Container(300).ListItem.Property(widget),Weather,left) + [!IsEmpty(Container(300).ListItem.Property(widget)) | [IsEmpty(Container(300).ListItem.Property(widget)) + [IsEmpty(Container(300).ListItem.Property(Background)) + [IsEmpty(Skin.String(home.slideshowpath))]]]]">Conditional</animation>
@@ -1125,7 +1125,7 @@
                             <control type="group">
                                 <width>593.33</width>
                                 <height>100%</height>
-                                
+
                                 <control type="image">
                                     <left>10</left>
                                     <top>10</top>
@@ -1188,7 +1188,7 @@
                             <control type="group">
                                 <width>593.33</width>
                                 <height>100%</height>
-                                
+
                                 <control type="image">
                                     <left>10</left>
                                     <top>10</top>
@@ -1251,7 +1251,7 @@
                             <control type="group">
                                 <width>593.33</width>
                                 <height>100%</height>
-                                
+
                                 <control type="image">
                                     <left>10</left>
                                     <top>10</top>
@@ -1313,7 +1313,7 @@
                             </control>
                         </control>
                     </control>
-                    
+
                     <!-- Container Updating -->
                     <control type="group" id="9201">
                         <centerleft>50%</centerleft>
@@ -1322,7 +1322,7 @@
                         <height>117</height>
                         <visible>Container(301).IsUpdating | [substring(Container(300).ListItem.Property(widget),Weather,left) + !Weather.IsFetched]</visible>
                         <animation effect="fade" start="0" end="100" delay="500" time="200" reversible="false">Visible</animation>
-                    
+
                         <control type="image">
                             <description>Busy animation</description>
                             <centerleft>54</centerleft>
@@ -1414,7 +1414,7 @@
                         </control>
                     </control>
                 </control>
-                
+
             </control>
             <!-- Home Row -->
             <control type="image">
@@ -1463,7 +1463,7 @@
             <include>Furniture_Clock</include>
         </control>
     </include>
-    
+
     <include name="HomeContentNoIcon">
         <top>948</top>
         <animation effect="fade" start="100" end="0" time="150" reversible="false" condition="Control.HasFocus(302) + Skin.HasSetting(home.submenu2)">Conditional</animation>
@@ -1520,7 +1520,7 @@
             <include>skinshortcuts-mainmenu</include>
         </content>
     </include>
-    
+
     <include name="HomeContentIcon">
         <top>848</top>
         <itemlayout width="220" height="220">
@@ -1588,9 +1588,9 @@
             <include>skinshortcuts-mainmenu</include>
         </content>
     </include>
- 
+
     <include name="HomeBackgroundPlaylist">
-        <control type="list" id="9988">           
+        <control type="list" id="9988">
             <description>hidden container for playlist background</description>
             <posx>-20</posx>
             <posy>-20</posy>
@@ -1643,7 +1643,7 @@
                     <effect type="zoom" end="95" start="100" time="200" center="auto" tween="quadratic" easing="in" />
                 </animation>
                 <!-- Home List -->
-                <control type="panel" id="300">    
+                <control type="panel" id="300">
                     <animation effect="fade" start="100" end="33" time="400" condition="Control.HasFocus(301)">Conditional</animation>
                     <animation effect="slide" start="-500" end="0" time="200" delay="100" tween="quadratic" easing="out">Visible</animation>
                     <visible allowhiddenfocus="true">!Control.HasFocus(302)</visible>
@@ -1730,7 +1730,7 @@
                     <visible allowhiddenfocus="true">Control.HasFocus(302)</visible>
                     <animation effect="fade" start="100" end="33" time="400" condition="Control.HasFocus(301)">Conditional</animation>
                     <animation effect="slide" start="-500" end="0" time="200" delay="100" tween="quadratic" easing="out">Visible</animation>
-                    
+
                     <include>Animation.FadeIn</include>
                     <include>Animation.FadeOut</include>
                     <description>Home Wraplist</description>
@@ -2053,7 +2053,7 @@
                             <height>252</height>
                             <orientation>horizontal</orientation>
                             <itemgap>0</itemgap>
-                            
+
                             <control type="group">
                                 <width>666</width>
                                 <height>100%</height>
@@ -2356,7 +2356,7 @@
                         <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                     </animation>
                 </control>
-                  
+
             </focusedlayout>
             <focusedlayout height="325" width="325" condition="StringCompare(Container(300).ListItem.Property(widgetaspect),Square)">
                 <control type="image">
@@ -2400,7 +2400,7 @@
                         <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                     </animation>
                 </control>
-                  
+
             </focusedlayout>
             <focusedlayout height="325" width="562" condition="StringCompare(Container(300).ListItem.Property(widgetaspect),Thumbnail) | StringCompare(Container(300).ListItem.Property(widgetaspect),Fanart)">
                 <control type="image">
@@ -2444,7 +2444,7 @@
                         <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                     </animation>
                 </control>
-                  
+
             </focusedlayout>
             <content target="$VAR[DefWidgetTarget]">$VAR[DefWidgetContent]</content>
         </control>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -141,7 +141,7 @@
         <value condition="Window.IsActive(playersettings)">$LOCALIZE[14200]</value>
         <value>$LOCALIZE[480]</value>
     </variable>
-    
+
     <variable name="WidgetLabel">
         <value condition="!IsEmpty(Container(300).ListItem.Property(widgetName))">$INFO[Container(300).ListItem.Property(widgetName)]</value>
         <value condition="!IsEmpty(Skin.String(home.fallbackwidget.name))">$INFO[Skin.String(home.fallbackwidget.name)]</value>
@@ -232,7 +232,7 @@
         <value condition="!IsEmpty(Window(Home).Property(NextAired.NextDate))">[COLOR=Dark1][B]$INFO[Window(Home).Property(NextAired.NextTitle),,  ][/B][/COLOR]$INFO[Window(Home).Property(NextAired.AirTime),, • ]$INFO[Window(Home).Property(NextAired.NextDate)]</value>
         <value condition="IsEmpty(Window(Home).Property(NextAired.NextDate)) + !IsEmpty(Window(Home).Property(NextAired.LatestTitle))">[COLOR=Dark1][B]$INFO[Window(Home).Property(NextAired.LatestTitle),,  ][/B][/COLOR]$INFO[Window(Home).Property(NextAired.Status),, • ]$INFO[Window(Home).Property(NextAired.LatestDate)]</value>
     </variable>
-    
+
     <variable name="LabelVideoInfoCastDirector">
         <value condition="StringCompare(Window.Property(content),1)">$INFO[ListItem.Studio,$LOCALIZE[31205] ,]</value>
         <value condition="StringCompare(Window.Property(content),2)">$INFO[ListItem.Title,$LOCALIZE[31204] ,]</value>

--- a/1080i/Includes_NextAired.xml
+++ b/1080i/Includes_NextAired.xml
@@ -43,7 +43,7 @@
             </control>
         </control>
     </include>
-    
+
     <include name="NextAiredListItem">
         <control type="image">
             <left>0</left>
@@ -122,5 +122,5 @@
         <value condition="!IsEmpty(ListItem.Property(Fanart))">$INFO[ListItem.Property(Fanart)]</value>
         <value>$INFO[ListItem.Thumb]</value>
     </variable>
-   
+
 </includes>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
-    
+
     <include name="OSDFocusStop"><defaultcontrol always="true">15</defaultcontrol></include>
     <include name="OSDFocusPause"><defaultcontrol always="true">14</defaultcontrol></include>
-    
+
     <include name="OSDInfoContent">
         <right>0</right>
         <control type="label" description="Video Info">
@@ -17,7 +17,7 @@
             <label>$INFO[VideoPlayer.AudioCodec,,  •  ]$VAR[LabelOSDAudioChannels,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoCodec,,]$INFO[VideoPlayer.RatingAndVotes,  •  ,]</label>
             <visible>!Skin.HasSetting(furniture.flagicons)</visible>
         </control>
-        
+
         <control type="grouplist">
             <visible>Skin.HasSetting(furniture.flagicons)</visible>
             <include>Animation.FadeIn</include>
@@ -80,7 +80,7 @@
                 <texture colordiffuse="$VAR[OSDPanelWhite70]">flags/3D.png</texture>
                 <visible>VideoPlayer.IsStereoscopic</visible>
             </control>
-            
+
             <control type="image">
                 <width>64</width>
                 <height>64</height>
@@ -97,7 +97,7 @@
                 <label>$INFO[VideoPlayer.Rating]</label>
                 <font>Flag</font>
                 <textcolor>$VAR[OSDPanelWhite70]</textcolor>
-            </control>            
+            </control>
         </control>
 
         <control type="label" description="Title">
@@ -137,7 +137,7 @@
             <label>$VAR[PlayerBigTitle]</label>
             <visible>Skin.HasSetting(furniture.flagicons)</visible>
         </control>
-        
+
         <control type="textbox" description="Plot">
             <width>100%</width>
             <top>105</top>
@@ -147,7 +147,7 @@
             <textcolor>$VAR[OSDPanelWhite30]</textcolor>
             <label>$VAR[PlayerPlotBox]</label>
         </control>
-        
+
         <control type="label" description="Elapsed Time">
             <width>400</width>
             <bottom>30</bottom>
@@ -207,7 +207,7 @@
         <texturefocus>noop</texturefocus>
         <width>226</width>
     </include>
-    
+
     <include name="DefOSDUpDown">
         <onup condition="IsEmpty(Window(home).Property(osdshowinfo)) + !Window.IsVisible(MusicOSD.xml)">SetProperty(osdshowinfo,1,home)</onup>
         <onup condition="!IsEmpty(Window(home).Property(osdshowinfo)) + !Window.IsVisible(MusicOSD.xml)">ClearProperty(osdshowinfo,home)</onup>
@@ -218,7 +218,7 @@
         <!-- <onup condition="Window.IsVisible(MusicOSD.xml)">IncreaseRating</onup>
         <ondown condition="Window.IsVisible(MusicOSD.xml)">DecreaseRating</ondown> -->
     </include>
-    
+
     <include name="OSDVideosRight">
         <control type="button" id="5">
             <description>3D Mode</description>
@@ -296,7 +296,7 @@
             <disabledcolor>White12</disabledcolor>
         </control>
     </include>
-    
+
     <variable name="OSDPanel">
         <value condition="[Skin.HasSetting(osd.usetheme)] | [!Window.IsVisible(fullscreenvideo) + !Window.IsVisible(visualisation)]">Background</value>
         <value>OSDBack</value>
@@ -323,7 +323,7 @@
     </variable>
 
     <include name="OSDAudioControls">
- 
+
         <control type="button" id="1">
             <description>Repeat</description>
             <onclick>XBMC.PlayerControl(Repeat)</onclick>
@@ -414,7 +414,7 @@
             <texturefocus colordiffuse="$VAR[ColorHighlight]">osd/lyrics.png</texturefocus>
             <texturenofocus colordiffuse="PanelWhite70">osd/lyrics.png</texturenofocus>
         </control>
-        
+
      <!--    <control type="button" id="3">
             <description>Playlist</description>
             <onclick>Close</onclick>
@@ -519,7 +519,7 @@
             <texturefocus colordiffuse="$VAR[ColorHighlight]">osd/visualisation.png</texturefocus>
             <texturenofocus colordiffuse="PanelWhite70">osd/visualisation.png</texturenofocus>
         </control>
-<!-- 
+<!--
         <control type="button" id="5">
             <description>Presets</description>
             <onclick>ActivateWindow(122)</onclick>
@@ -571,7 +571,7 @@
     </include>
 
     <include name="OSDAudioControlsFlip">
- 
+
         <control type="button" id="1">
             <description>Repeat</description>
             <onclick>XBMC.PlayerControl(Repeat)</onclick>
@@ -662,7 +662,7 @@
             <texturefocus colordiffuse="$VAR[ColorHighlight]">osd/lyrics.png</texturefocus>
             <texturenofocus colordiffuse="Dark1">osd/lyrics.png</texturenofocus>
         </control>
-        
+
         <!-- <control type="button" id="3">
             <description>Playlist</description>
             <onclick>Close</onclick>
@@ -759,7 +759,7 @@
         </control>
 
 
-   
+
         <control type="button" id="500">
             <description>Vis</description>
             <width>48</width>
@@ -845,7 +845,7 @@
             <visible>VideoPlayer.Content(LiveTV)</visible>
             <animation effect="fade" start="100" end="33" time="100" condition="!Player.CanRecord">Conditional</animation>
         </control>
-        
+
         <control type="button" id="12">
             <description>Skip Back</description>
             <width>48</width>
@@ -927,7 +927,7 @@
             <texturenofocus colordiffuse="PanelWhite70">osd/next.png</texturenofocus>
             <onclick>PlayerControl(Next)</onclick>
         </control>
-        
+
         <control type="button" id="9002">
             <width>48</width>
             <height>48</height>
@@ -957,7 +957,7 @@
             <visible>VideoPlayer.Content(LiveTV)</visible>
             <animation effect="fade" start="100" end="33" time="100" condition="!Player.CanRecord">Conditional</animation>
         </control>
-        
+
         <control type="button" id="12">
             <description>Skip Back</description>
             <width>48</width>
@@ -1039,7 +1039,7 @@
             <texturenofocus colordiffuse="Dark1">osd/next.png</texturenofocus>
             <onclick>PlayerControl(Next)</onclick>
         </control>
-        
+
         <control type="button" id="9002">
             <width>48</width>
             <height>48</height>
@@ -1063,7 +1063,7 @@
             <height>100</height>
             <include>Animation.FadeIn.Slide</include>
             <include>Animation.FadeOut</include>
-            
+
             <control type="image">
                 <description>background image</description>
                 <posx>0</posx>
@@ -1143,7 +1143,7 @@
 
             </control>
         </control>
-        
+
     </include>
-    
+
 </includes>

--- a/1080i/Includes_PVR.xml
+++ b/1080i/Includes_PVR.xml
@@ -48,8 +48,8 @@
                     <include>DefContextButton</include>
                     <align>left</align>
                 </control>
-                
-                
+
+
                 <!-- PVR options -->
                 <!-- <control type="label" id="9010">
                     <description>Channels</description>
@@ -103,14 +103,14 @@
                     <align>left</align>
                     <visible>Window.IsVisible(MyPVRChannels.xml)</visible>
                 </control>
-                
+
             </control>
         </control>
     </include>
 
     <include name="PVRInfoPanel">
 
-      
+
         <control type="group">
             <left>70</left>
             <width>645</width>
@@ -156,7 +156,7 @@
                 <right>20</right>
                 <posy>370</posy>
                 <height>290</height>
-                
+
                 <control type="label">
                     <top>8</top>
                     <aligny>center</aligny>
@@ -185,7 +185,7 @@
                     <label fallback="19055">$INFO[ListItem.Plot]</label>
                 </control>
             </control>
-        
+
         </control>
     </include>
     <variable name="ProgressPercent">
@@ -299,8 +299,8 @@
                 <width>1100</width>
                 <top>PosterPad</top>
                 <height>640</height>
-               
-                <control type="list" id="50" description="TV CHANNELS">     
+
+                <control type="list" id="50" description="TV CHANNELS">
                     <right>0</right>
                     <width>1100</width>
                     <top>0</top>
@@ -340,7 +340,7 @@
                             <texture colordiffuse="$VAR[ColorHighlight]">progress/play.png</texture>
                             <visible>ListItem.IsPlaying</visible>
                         </control>
-                        <control type="image">                                
+                        <control type="image">
                             <left>10</left>
                             <centertop>50%</centertop>
                             <width>111</width>
@@ -466,10 +466,10 @@
                                 <visible>!stringcompare(ListItem.Label,..)</visible>
                             </control>
                         </control>
-                    
+
                     </itemlayout>
-                    
-                    
+
+
                     <focusedlayout height="128" width="1100">
 
                         <control type="group">
@@ -505,7 +505,7 @@
                                 <texture colordiffuse="$VAR[ColorHighlight]">progress/play.png</texture>
                                 <visible>ListItem.IsPlaying</visible>
                             </control>
-                            <control type="image">                                
+                            <control type="image">
                                 <left>10</left>
                                 <centertop>50%</centertop>
                                 <width>111</width>
@@ -513,7 +513,7 @@
                                 <aspectratio align="left">keep</aspectratio>
                                 <texture fallback="DefaultAddonNone.png">$INFO[Listitem.Icon]</texture>
                             </control>
-                            
+
                             <control type="group">
                                 <visible>Window.IsVisible(MyPVRChannels.xml)</visible>
                                 <control type="progress">
@@ -661,7 +661,7 @@
                                 <texture colordiffuse="$VAR[ColorHighlight]">progress/play.png</texture>
                                 <visible>ListItem.IsPlaying</visible>
                             </control>
-                            <control type="image">                                
+                            <control type="image">
                                 <left>10</left>
                                 <centertop>50%</centertop>
                                 <width>111</width>
@@ -671,7 +671,7 @@
                             </control>
                             <control type="group">
                                 <visible>Window.IsVisible(MyPVRChannels.xml)</visible>
-                                
+
                                 <control type="progress">
                                     <posx>150</posx>
                                     <bottom>14</bottom>
@@ -780,11 +780,11 @@
                                     <label>$INFO[ListItem.ChannelName]</label>
                                 </control>
                             </control>
-                        
-                        
+
+
                         </control>
-                    
-                        
+
+
                     </focusedlayout>
                 </control>
             </control>
@@ -798,9 +798,9 @@
             <visible>Control.IsVisible(51)</visible>
             <include>Animation.Common</include>
             <control type="group">
-          
-                
-                <control type="panel" id="51" description="TV CHANNELS">     
+
+
+                <control type="panel" id="51" description="TV CHANNELS">
                     <top>206</top>
                     <height>660</height>
                     <left>70</left>
@@ -821,10 +821,10 @@
                             <bottom>10</bottom>
                             <texture colordiffuse="Dark4" border="5">common/box.png</texture>
                         </control>
-                        
+
                         <control type="group">
                             <visible>Window.IsVisible(MyPVRChannels.xml)</visible>
-                            <control type="image">                                
+                            <control type="image">
                                 <left>20</left>
                                 <top>20</top>
                                 <width>220</width>
@@ -906,7 +906,7 @@
                         </control>
                         <control type="group">
                             <visible>!Window.IsVisible(MyPVRChannels.xml)</visible>
-                            <control type="image">                                
+                            <control type="image">
                                 <left>20</left>
                                 <top>20</top>
                                 <width>290</width>
@@ -961,11 +961,11 @@
                                 <selectedcolor>Dark1</selectedcolor>
                                 <label>$INFO[ListItem.StartDate]$INFO[ListItem.StartTime,$COMMA  ,]</label>
                             </control>
-                            
-                        
+
+
                         </control>
-                        
-                        
+
+
                     </itemlayout>
                     <focusedlayout height="330" width="890">
                         <control type="image">
@@ -977,7 +977,7 @@
                         </control>
                         <control type="group">
                             <visible>Window.IsVisible(MyPVRChannels.xml)</visible>
-                            <control type="image">                                
+                            <control type="image">
                                 <left>20</left>
                                 <top>20</top>
                                 <width>220</width>
@@ -1058,7 +1058,7 @@
                         </control>
                         <control type="group">
                             <visible>!Window.IsVisible(MyPVRChannels.xml)</visible>
-                            <control type="image">                                
+                            <control type="image">
                                 <left>20</left>
                                 <top>20</top>
                                 <width>290</width>
@@ -1112,13 +1112,13 @@
                                 <selectedcolor>Light1</selectedcolor>
                                 <label>$INFO[ListItem.StartDate]$INFO[ListItem.StartTime,$COMMA  ,]</label>
                             </control>
-                            
-                        
+
+
                         </control>
-                        
+
                     </focusedlayout>
                 </control>
-                
+
             </control>
             <include>Furniture_Scrollbar</include>
         </control>
@@ -1132,8 +1132,8 @@
     <include name="PVRView_52">
         <control type="group">
             <visible>Control.IsVisible(52)</visible>
-            <include>Animation.Common</include>     
-            <control type="panel" id="52" description="TV CHANNELS">     
+            <include>Animation.Common</include>
+            <control type="panel" id="52" description="TV CHANNELS">
                 <top>206</top>
                 <height>495</height>
                 <left>70</left>
@@ -1154,7 +1154,7 @@
                         <bottom>10</bottom>
                         <texture colordiffuse="Dark4" border="5">common/box.png</texture>
                     </control>
-                    <control type="image">                                
+                    <control type="image">
                         <right>20</right>
                         <top>20</top>
                         <width>100</width>
@@ -1242,7 +1242,7 @@
                         <bottom>10</bottom>
                         <texture colordiffuse="Dark1" border="5">common/box.png</texture>
                     </control>
-                    <control type="image">                                
+                    <control type="image">
                         <right>20</right>
                         <top>20</top>
                         <width>100</width>

--- a/1080i/LoginScreen.xml
+++ b/1080i/LoginScreen.xml
@@ -1,6 +1,6 @@
 <window>
     <defaultcontrol always="true">52</defaultcontrol>
-    
+
     <backgroundcolor>0</backgroundcolor>
     <onload condition="IsEmpty(Window(home).Property(SkinInitStarted)) + !IsEmpty(Skin.String(StartupPlaylist))">PlayMedia($ESCINFO[Skin.String(StartupPlaylist)])</onload>
     <onload>SetProperty(SkinInitStarted,1,home)</onload>
@@ -47,7 +47,7 @@
                     </control>
                 </itemlayout>
                 <focusedlayout height="120">
-                    <control type="image">                                
+                    <control type="image">
                         <left>8</left>
                         <centertop>50%</centertop>
                         <width>111</width>
@@ -58,7 +58,7 @@
                         <animation effect="slide" start="0,-120" end="0,0" time="300" reversible="false" tween="back" easing="out" condition="Container(52).OnNext">Focus</animation>
                         <visible>!Skin.HasSetting(global.hidecirles)</visible>
                     </control>
-                    <control type="image">                                
+                    <control type="image">
                         <left>8</left>
                         <centertop>50%</centertop>
                         <width>111</width>
@@ -69,7 +69,7 @@
                         <animation effect="slide" start="0,-120" end="0,0" time="300" reversible="false" tween="back" easing="out" condition="Container(52).OnNext">Focus</animation>
                         <visible>Skin.HasSetting(global.hidecirles)</visible>
                     </control>
-          
+
                     <control type="group">
                         <animation type="Focus" condition="Container(52).OnNext | Container(52).OnPrevious" reversible="false">
                             <effect type="fade" start="50" end="100" time="300" tween="sine" easing="inout" />

--- a/1080i/MusicOSD.xml
+++ b/1080i/MusicOSD.xml
@@ -74,9 +74,9 @@
                         <aspectratio align="center">keep</aspectratio>
                         <visible>!IsEmpty(Player.Duration)</visible>
                     </control>
-                  
+
                 </control>
-        
+
                 <control type="label">
                     <left>30</left>
                     <right>30</right>
@@ -117,7 +117,7 @@
                     <itemgap>12</itemgap>
                     <visible>true</visible>
                     <usecontrolcoords>true</usecontrolcoords>
-                    
+
                     <control type="label" description="Artist">
                         <top>0</top>
                         <width>100%</width>
@@ -127,7 +127,7 @@
                         <textcolor>$VAR[OSDPanelWhite70]</textcolor>
                         <label>$VAR[PlayerBigTitle]</label>
                     </control>
-                    
+
                     <control type="label" description="Song">
                         <width>100%</width>
                         <height>40</height>
@@ -182,7 +182,7 @@
                             <texture>flags/$VAR[OSDMusicFlagstar5].png</texture>
                         </control>
                     </control>
-                    
+
                     <control type="label" description="AlbumYear">
                         <width>100%</width>
                         <height>40</height>
@@ -464,7 +464,7 @@
                             <onclick>Playlist.PlayOffset(-1)</onclick>
                             <visible>MusicPlayer.offset(-1).Exists</visible>
                         </item>
-                        
+
                         <item id="21">
                             <label>$INFO[MusicPlayer.offset(0).Title]</label>
                             <label2>$INFO[MusicPlayer.offset(0).Duration]</label2>
@@ -617,7 +617,7 @@
                 </control>
             </control>
 
-            
+
             <control type="group">
                 <height>64</height>
                 <bottom>64</bottom>
@@ -634,12 +634,12 @@
                     <include condition="Skin.HasSetting(osd.usetheme)">OSDAudioControlsFlip</include>
                 </control>
 
-                
+
             </control>
         </control>
-        
-        
-    
+
+
+
     </controls>
 
 </window>

--- a/1080i/MusicVisualisation.xml
+++ b/1080i/MusicVisualisation.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="2006">
     <defaultcontrol always="true">-</defaultcontrol>
-    
+
     <onload condition="Skin.HasSetting(osd.alwaysshowmusicosd)">ActivateWindow(musicosd)</onload>
 
     <controls>
@@ -34,9 +34,9 @@
             <animation effect="zoom" start="110" end="130" center="auto" time="10000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(ArtistSlideshow.Animate)">Conditional</animation>
             <animation effect="slide" start="-30,-30" end="30,30" time="6000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(ArtistSlideshow.Animate)">Conditional</animation>
         </control>
-        
 
-        
+
+
         <control type="image">
             <height>100%</height>
             <width>100%</width>
@@ -67,7 +67,7 @@
                 <top>110r</top>
                 <bottom>0</bottom>
                 <width>100%</width>
-                
+
                 <control type="group">
                     <left>SidePad</left>
                     <right>SidePad</right>
@@ -92,7 +92,7 @@
                         <textcolor>$VAR[OSDPanelWhite70]</textcolor>
                         <label>$INFO[Player.Time]$INFO[Player.Duration,  /  ,]</label>
                     </control>
-          
+
                     <control type="progress" description="cache">
                         <description>Progress Bar</description>
                         <width>100%</width>
@@ -115,8 +115,8 @@
                 </control>
             </control>
         </control>
-        
-    
+
+
         <control type="group">
             <visible>Player.ShowCodec</visible>
             <visible>!Window.IsVisible(script-cu-lrclyrics-main.xml)</visible>
@@ -146,8 +146,8 @@
                 <textcolor>$VAR[OSDPanelWhite100]</textcolor>
             </control>
         </control>
-        
-        
+
+
     </controls>
 
 </window>

--- a/1080i/MyMusicNav.xml
+++ b/1080i/MyMusicNav.xml
@@ -4,7 +4,7 @@
     <defaultcontrol always="true">50</defaultcontrol>
     <menucontrol>9000</menucontrol>
     <views>50,505,506,507,500,503,54,57,51</views>
-    
+
     <controls>
 
         <include>GlobalBackground</include>
@@ -21,7 +21,7 @@
         <include>View_54_Banner</include>
         <include condition="!Skin.HasSetting(57list.low)">View_57_ExtraInfo</include>
         <include condition="Skin.HasSetting(57list.low)">View_57_ExtraInfo_LowList</include>
-        
+
         <control type="group">
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
@@ -34,7 +34,7 @@
             <control type="grouplist" id="9000">
                 <include>Def9000GroupList</include>
                 <include>Def9000MusicSide</include>
-                
+
                 <control type="radiobutton" id="9007" description="Low List (57)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -44,7 +44,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(57)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9008" description="Big Wide Info (51)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -54,7 +54,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(51)</visible>
                 </control>
-              
+
                 <control type="button" id="9091">
                     <description>Global Search</description>
                     <include>DefContextButton</include>
@@ -89,7 +89,7 @@
                 </control>
             </control>
         </control>
-        
+
 
     </controls>
 

--- a/1080i/MyMusicPlaylistEditor.xml
+++ b/1080i/MyMusicPlaylistEditor.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window>
     <defaultcontrol allways="true">50</defaultcontrol>
-    
+
 
     <controls>
 
@@ -11,15 +11,15 @@
         <include>Furniture_Clock</include>
         <include>Furniture_NowPlaying</include>
         <include>Furniture_Weather</include>
-        
+
         <control type="label" id="12">
             <visible>false</visible>
         </control>
-        
+
         <control type="label" id="101">
             <visible>false</visible>
         </control>
-        
+
         <control type="group">
             <include>Animation.Common</include>
             <control type="group">
@@ -28,7 +28,7 @@
                 <top>PosterPad</top>
                 <height>640</height>
                 <width>870</width>
-            
+
                 <control type="image">
                     <width>100%</width>
                     <height>100%</height>
@@ -59,7 +59,7 @@
 
                     <itemlayout height="69" width="840">
 
-                        
+
 
                         <control type="label">
                             <posx>30</posx>
@@ -111,8 +111,8 @@
                 </control>
 
             </control>
-       
-            
+
+
             <control type="group">
                 <description>Right panel</description>
                 <right>SidePad</right>
@@ -149,7 +149,7 @@
 
                     <itemlayout height="69" width="840">
 
-                        
+
 
                         <control type="label">
                             <posx>30</posx>
@@ -201,8 +201,8 @@
                 </control>
 
             </control>
-            
-            
+
+
         </control>
         <control type="group">
             <include>Animation.FadeIn</include>
@@ -234,8 +234,8 @@
 
             </control>
         </control>
-        
-        
+
+
     </controls>
 
 </window>

--- a/1080i/MyPVRGuide.xml
+++ b/1080i/MyPVRGuide.xml
@@ -25,7 +25,7 @@
                     <bottom>-8</bottom>
                     <texture colordiffuse="Panel" border="16">common/rounded-shadow8.png</texture>
                 </control>
-                
+
                 <control type="group">
                     <top>500</top>
                     <bottom>10</bottom>
@@ -60,8 +60,8 @@
                         <texture>$INFO[ListItem.Icon]</texture>
                     </control>
                 </control>
-                
-                <control type="epggrid" id="10" description="EPG">     
+
+                <control type="epggrid" id="10" description="EPG">
                     <left>0</left>
                     <top>-60</top>
                     <width>1760</width>
@@ -120,7 +120,7 @@
                         </control>
                     </channellayout>
                     <focusedchannellayout height="70" width="460">
-                        
+
                         <control type="image">
                             <width>100%</width>
                             <height>67</height>
@@ -161,22 +161,22 @@
                             <texture>$INFO[ListItem.Icon]</texture>
                             <aspectratio aligny="center" align="right">keep</aspectratio>
                         </control>
-                    </focusedchannellayout>    
+                    </focusedchannellayout>
                     <itemlayout height="70" width="260">
-                        
+
                         <control type="image" id="2">
                             <width>256</width>
                             <height>67</height>
                             <texture border="5">common/white.png</texture>
                             <colordiffuse>Black12</colordiffuse>
-                        </control> 
+                        </control>
                         <control type="image" id="2">
                             <width>257</width>
                             <height>67</height>
                             <texture>pvrgenre/$INFO[ListItem.Property(GenreType)].png</texture>
                             <aspectratio>scale</aspectratio>
                             <colordiffuse>5fffffff</colordiffuse>
-                        </control> 
+                        </control>
                         <control type="image">
                             <posy>6</posy>
                             <width>52</width>
@@ -184,7 +184,7 @@
                             <texture>special://skin/extras/icons/timer.png</texture>
                             <colordiffuse>PanelWhite70</colordiffuse>
                             <visible>ListItem.HasTimer | ListItem.IsRecording</visible>
-                        </control>   
+                        </control>
                         <control type="label" id="1">
                             <posx>0</posx>
                             <height>66</height>
@@ -205,14 +205,14 @@
                         </control>
                     </itemlayout>
                     <focusedlayout height="70" width="260">
-        
+
                         <control type="image" id="2">
                             <width>256</width>
                             <height>67</height>
                             <texture border="5">common/white.png</texture>
                             <colordiffuse>$VAR[ColorHighlight]</colordiffuse>
-                        </control> 
-                        
+                        </control>
+
                         <control type="image">
                             <posy>6</posy>
                             <width>52</width>
@@ -220,7 +220,7 @@
                             <texture>special://skin/extras/icons/timer.png</texture>
                             <colordiffuse>Selected</colordiffuse>
                             <visible>ListItem.HasTimer | ListItem.IsRecording</visible>
-                        </control>   
+                        </control>
                         <control type="label" id="1">
                             <posx>0</posx>
                             <height>66</height>
@@ -240,10 +240,10 @@
                             <visible>!ListItem.HasTimer + !ListItem.IsRecording</visible>
                         </control>
                     </focusedlayout>
-                
+
                 </control>
             </control>
-        
+
         </control>
         <include>PVRSideBlade</include>
     </controls>

--- a/1080i/MyPlaylist.xml
+++ b/1080i/MyPlaylist.xml
@@ -13,8 +13,8 @@
         <include>Furniture_Clock</include>
         <include>Furniture_Flags</include>
         <include>Furniture_Weather</include>
-        
-        
+
+
         <control type="group">
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
@@ -49,21 +49,21 @@
                     <label>584</label>
                     <altlabel>585</altlabel>
                 </control>
-                
+
                 <control type="radiobutton" id="20">
                     <description>Shuffle</description>
                     <include>DefContextButton</include>
                     <align>left</align>
                     <label>191</label>
                 </control>
-                
+
                 <control type="button" id="26">
                     <description>Repeat</description>
                     <include>DefContextButton</include>
                     <align>left</align>
                     <label>486</label>
                 </control>
-                
+
                 <control type="button" id="21">
                     <description>Save</description>
                     <include>DefContextButton</include>

--- a/1080i/MyPrograms.xml
+++ b/1080i/MyPrograms.xml
@@ -27,7 +27,7 @@
             <include>Def9000Background</include>
             <control type="grouplist" id="9000">
                 <include>Def9000GroupList</include>
-                
+
                 <control type="button" id="2">
                     <description>View</description>
                     <include>DefContextButton</include>

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -5,7 +5,7 @@
     <menucontrol>9000</menucontrol>
     <views>50,550,56,57,53,55,555,59,54,51,58,52,500</views>
     <onload condition="System.HasAddon(script.tv.show.next.aired)">RunScript(script.tv.show.next.aired,backend=True)</onload>
-    
+
     <controls>
 
         <include>GlobalBackground</include>
@@ -31,14 +31,14 @@
         <include>View_58_Cards</include>
         <include>View_59_BannerWall</include>
         <include>View_500_Thumbnails</include>
-        
+
         <include>Furniture_Header</include>
         <include>Furniture_NowPlaying</include>
         <include>Furniture_Clock</include>
         <include>Furniture_Flags</include>
         <include>Furniture_Weather</include>
         <include>Furniture_OverlayInfo</include>
-        
+
         <control type="group">
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
@@ -70,14 +70,14 @@
                 <height>490</height>
                 <usecontrolcoords>true</usecontrolcoords>
                 <include>Def9000GroupList</include>
-                
+
                 <!-- Sort Options -->
                 <control type="button" id="2">
                     <description>View</description>
                     <include>DefContextButton</include>
                     <align>left</align>
                 </control>
-                
+
                 <control type="button" id="3">
                     <description>Sort</description>
                     <include>DefContextButton</include>
@@ -91,7 +91,7 @@
                     <label>584</label>
                     <altlabel>585</altlabel>
                 </control>
-                
+
                 <!-- View Options -->
                 <control type="radiobutton" id="9001" description="Low List (50)">
                     <include>DefContextButton</include>
@@ -102,7 +102,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(50)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9009" description="Low List (50)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -111,7 +111,7 @@
                     <onclick>Skin.ToggleSetting(50list.showplot)</onclick>
                     <visible>Control.IsVisible(50) + !Skin.HasSetting(50list.low)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9002" description="No Wrap (53)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -121,7 +121,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(53)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9003" description="Info Wall (55)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -132,7 +132,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(55)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9004" description="Poster Wall (55)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -143,7 +143,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(55)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9005" description="Info Media (56)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -154,7 +154,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(56)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9006" description="Low List Media (56)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -165,7 +165,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(56)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9007" description="Low List (57)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -175,7 +175,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(57)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9008" description="Big Wide Info (51)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -186,7 +186,7 @@
                     <onclick>ReloadSkin()</onclick>
                     <visible>Control.IsVisible(51)</visible>
                 </control>
-                
+
                 <control type="radiobutton" id="9011" description="Banner show poster (54)">
                     <include>DefContextButton</include>
                     <align>left</align>
@@ -230,7 +230,7 @@
                     <align>left</align>
                     <label>31133</label>
                 </control>
-                
+
                 <control type="radiobutton" id="11">
                     <description>Unlock Shares</description>
                     <include>DefContextButton</include>
@@ -248,7 +248,7 @@
                     <label>589</label>
                     <visible>Container.Content(MusicVideo)</visible>
                 </control>
-                
+
                 <control type="edit" id="19">
                     <label>587</label>
                     <description>Filter (hidden)</description>
@@ -266,7 +266,7 @@
                     <onclick>Filter</onclick>
                     <selected>Container.Filtered</selected>
                 </control>
-                
+
                 <control type="button" id="9091">
                     <description>Global Search</description>
                     <include>DefContextButton</include>
@@ -275,7 +275,7 @@
                     <onclick>SetFocus(50)</onclick>
                     <onclick>RunScript(script.globalsearch,tvshows=true&amp;movies=true&amp;episodes=true&amp;actors=true)</onclick>
                 </control>
-                
+
                 <control type="button" id="9098">
                     <description>Video Playlist</description>
                     <include>DefContextButton</include>
@@ -293,10 +293,10 @@
                 </control>
             </control>
         </control>
-        
-        
-    
-        
+
+
+
+
     </controls>
 
 </window>

--- a/1080i/MyWeather.xml
+++ b/1080i/MyWeather.xml
@@ -410,8 +410,8 @@
                     </control>
                 </control>
             </control>
-            
-            
+
+
         </control>
         <control type="button" id="9100" description="Fake Button">
             <visible allowhiddenfocus="true">false</visible>
@@ -440,7 +440,7 @@
                 <onback>9100</onback>
                 <usecontrolcoords>true</usecontrolcoords>
                 <include>Def9000GroupList</include>
-                
+
                 <!-- Weather Options -->
                 <control type="button" id="9008" description="Weather Location">
                     <include>DefContextButton</include>
@@ -449,7 +449,7 @@
                     <label2>$INFO[Weather.Location]</label2>
                     <onclick>Weather.LocationNext</onclick>
                 </control>
-                
+
                 <control type="radiobutton" id="9002" description="Show weather overlay">
                     <include>DefContextButton</include>
                     <align>left</align>

--- a/1080i/PlayerControls.xml
+++ b/1080i/PlayerControls.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window type="dialog" id="400">
     <defaultcontrol always="true">300</defaultcontrol>
-    
+
     <visible>false</visible>
     <controls>
     </controls>

--- a/1080i/RecordPrefs.xml
+++ b/1080i/RecordPrefs.xml
@@ -6,12 +6,12 @@
 
         <control type="group">
             <include>DefDialogBackground</include>
-            
+
             <control type="label" id="20">
                 <include>DefDialogHeader</include>
                 <label>$ADDON[pvr.wmc 30100]</label>
             </control>
-  
+
             <control type="grouplist" id="9002">
                 <description>Control Area</description>
                 <left>38</left>
@@ -85,6 +85,6 @@
             </control>
 
         </control>
-    
+
     </controls>
 </window>

--- a/1080i/Settings.xml
+++ b/1080i/Settings.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="4">
     <defaultcontrol always="true">9100</defaultcontrol>
-    
+
     <controls>
         <include>GlobalBackground</include>
         <include>Furniture_Header</include>
@@ -67,7 +67,7 @@
                     <height>1</height>
                     <texture colordiffuse="Black12">common/white.png</texture>
                 </control>-->
-               
+
             </control>
             <control type="Panel" id="9100">
                 <left>0</left>
@@ -100,7 +100,7 @@
                         <height>106.7</height>
                         <texture colordiffuse="PanelWhite100">$INFO[ListItem.Icon]</texture>
                     </control>
-                
+
                 </itemlayout>
                 <focusedlayout width="575" height="128.4">
                     <control type="image">
@@ -135,7 +135,7 @@
                         <icon>special://skin/extras/icons/swissarmy.png</icon>
                         <onclick>activatewindow(InterfaceSettings)</onclick>
                     </item>
-                    
+
                     <item id="2">
                         <label>14202</label>
                         <label2>31276</label2>
@@ -148,7 +148,7 @@
                         <icon>special://skin/extras/icons/equalizer.png</icon>
                         <onclick>activatewindow(PlayerSettings)</onclick>
                     </item>
-                    
+
                     <item id="12">
                         <label>20077</label>
                         <label2>31166</label2>
@@ -167,7 +167,7 @@
                         <icon>special://skin/extras/icons/network.png</icon>
                         <onclick>activatewindow(servicesettings)</onclick>
                     </item>
-                    
+
                     <item id="9">
                         <label>13200</label>
                         <label2>31165</label2>
@@ -180,7 +180,7 @@
                         <icon>special://skin/extras/icons/addons.png</icon>
                         <onclick>activatewindow(AddonBrowser)</onclick>
                     </item>
-                    
+
                     <item id="10">
                         <label>130</label>
                         <label2>31167</label2>
@@ -193,11 +193,11 @@
                         <icon>special://skin/extras/icons/livetv.png</icon>
                         <onclick>activatewindow(pvrsettings)</onclick>
                     </item>
-                    
-                    
+
+
                 </content>
             </control>
-            
+
         </control>
     </controls>
 

--- a/1080i/SettingsCategory.xml
+++ b/1080i/SettingsCategory.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="12">
     <defaultcontrol always="true">3</defaultcontrol>
-    
+
     <onunload condition="!Skin.HasSetting(startup.init)">Skin.SetBool(osd.usetheme)</onunload>
     <onunload condition="!Skin.HasSetting(startup.init)">Skin.SetBool(global.hidecirles)</onunload>
     <onunload condition="!Skin.HasSetting(startup.init)">Skin.SetBool(home.classicwidgets)</onunload>
@@ -20,13 +20,13 @@
             <right>72</right>
             <top>208</top>
             <height>656</height>
-            
+
             <control type="image">
                 <width>100%</width>
                 <height>100%</height>
                 <texture border="16" colordiffuse="Panel">common/rounded-shadow8.png</texture>
             </control>
-            
+
             <control type="group">
                 <left>8</left>
                 <right>8</right>
@@ -45,7 +45,7 @@
                     <ondown>5</ondown>
                     <orientation>vertical</orientation>
                 </control>
-                
+
                 <!-- Left Group -->
                 <control type="grouplist" id="3">
                     <description>Button Area</description>
@@ -59,7 +59,7 @@
                     <ondown>3</ondown>
                     <orientation>vertical</orientation>
                 </control>
-                
+
                 <!-- Lines -->
                 <control type="image">
                     <top>10</top>
@@ -69,8 +69,8 @@
                     <colordiffuse>Black12</colordiffuse>
                     <texture>common/white.png</texture>
                 </control>
-         
-                
+
+
                 <!-- Header -->
                 <control type="label">
                     <left>30</left>
@@ -118,9 +118,9 @@
                 </control>
             </control>
         </control>
-        
+
         script-script.extendedinfo-
-        
+
         <control type="button" id="7">
             <description>Default Button</description>
             <include>DefSettingsButton</include>

--- a/1080i/SettingsProfile.xml
+++ b/1080i/SettingsProfile.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="34">
     <defaultcontrol always="true">4</defaultcontrol>
-    
+
 
     <controls>
         <include>GlobalBackground</include>
@@ -15,7 +15,7 @@
         <control type="group">
             <width>700</width>
             <include>DefDialogInfoPanel</include>
-            
+
             <control type="label">
                 <description>Header Label</description>
                 <centerleft>50%</centerleft>
@@ -66,7 +66,7 @@
 
                 <focusedlayout height="69" width="670">
                     <control type="group">
-                        
+
                         <visible>Control.HasFocus(2)</visible>
                         <control type="image">
                             <width>100%</width>

--- a/1080i/SettingsScreenCalibration.xml
+++ b/1080i/SettingsScreenCalibration.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="11">
 	<defaultcontrol always="true">8</defaultcontrol>
-	
+
 
 	<controls>
 

--- a/1080i/SettingsSystemInfo.xml
+++ b/1080i/SettingsSystemInfo.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="7">
     <defaultcontrol always="true">95</defaultcontrol>
-    
+
 
     <controls>
 
@@ -17,13 +17,13 @@
             <right>72</right>
             <top>208</top>
             <height>656</height>
-            
+
             <control type="image">
                 <width>100%</width>
                 <height>100%</height>
                 <texture border="16" colordiffuse="Panel">common/rounded-shadow8.png</texture>
             </control>
-            
+
             <control type="group">
                 <left>8</left>
                 <right>8</right>
@@ -74,7 +74,7 @@
                     <textcolor>PanelWhite70</textcolor>
                     <scroll>true</scroll>
                 </control>
-                
+
                 <!-- Left Group -->
                 <control type="grouplist" id="9101">
                     <width>450</width>
@@ -113,7 +113,7 @@
                         <include>DefSettingsButton</include>
                         <label>13281</label>
                     </control>
-                    
+
                     <control type="button" id="99">
                         <description>Live TV</description>
                         <include>DefSettingsButton</include>
@@ -155,7 +155,7 @@
                         <info>System.CPUUsage</info>
                         <include>DefSettingsButton</include>
                     </control>
-                    
+
                     <control type="label">
                         <description>Memory Text</description>
                         <posy>-70</posy>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -1,6 +1,6 @@
 <window>
     <defaultcontrol>30</defaultcontrol>
-    
+
     <defaultcontrol always="true">9101</defaultcontrol>
 
     <controls>
@@ -15,13 +15,13 @@
             <right>72</right>
             <top>208</top>
             <height>656</height>
-            
+
             <control type="image">
                 <width>100%</width>
                 <height>100%</height>
                 <texture border="16" colordiffuse="Panel">common/rounded-shadow8.png</texture>
             </control>
-            
+
             <control type="group">
                 <left>8</left>
                 <right>8</right>
@@ -63,7 +63,7 @@
                         <include>DefSettingsButton</include>
                         <label>31270</label>
                     </control>
-                    
+
                     <control type="togglebutton" id="9107" description="Extras">
                         <usealttexture>ControlGroup(9100).HasFocus(9107)</usealttexture>
                         <alttexturenofocus colordiffuse="$VAR[ColorHighlight]">common/white.png</alttexturenofocus>
@@ -71,8 +71,8 @@
                         <label>31169</label>
                     </control>
                 </control>
-                
-                
+
+
                 <!-- Right Group -->
                 <control type="grouplist" id="9200">
                     <description>Control Area</description>
@@ -106,19 +106,19 @@
                         <onclick condition="!Skin.HasSetting(home.vertical) + !Skin.HasSetting(home.classicwidgets)">Skin.Reset(home.vertical)</onclick>
                         <onclick condition="!Skin.HasSetting(home.vertical) + !Skin.HasSetting(home.classicwidgets)">Skin.SetBool(home.classicwidgets)</onclick>
                     </control>
-                    
+
                     <control type="button" id="9241" description="Set Slideshow Path">
                         <width>1310</width>
                         <visible>ControlGroup(9100).HasFocus(9101)</visible>
                         <include>DefSettingsButton</include>
                         <label>31269</label>
                         <label2>$VAR[LabelFallbackWidgetName]</label2>
-                        <onclick>ActivateWindow(1106)</onclick> 
+                        <onclick>ActivateWindow(1106)</onclick>
                     </control>
-                    
-                    
-                    
-                    
+
+
+
+
                     <!-- <control type="button" id="9212" description="Reset Home to Defaults">
                         <width>1310</width>
                         <visible>ControlGroup(9100).HasFocus(9101)</visible>
@@ -126,7 +126,7 @@
                         <label>31132</label>
                         <onclick>RunScript(script.skinshortcuts,type=resetall)</onclick>
                     </control> -->
-                    
+
                     <control type="radiobutton" id="9243" description="Show slideshow instead of fanart">
                         <width>1310</width>
                         <visible>ControlGroup(9100).HasFocus(9101)</visible>
@@ -153,7 +153,7 @@
                         <selected>Skin.HasSetting(NoPersistentWidgets)</selected>
                         <onclick>Skin.ToggleSetting(NoPersistentWidgets)</onclick>
                     </control>
-                    
+
                     <control type="radiobutton" id="9216" description="Show Icons">
                         <width>1310</width>
                         <visible>ControlGroup(9100).HasFocus(9101)</visible>
@@ -162,7 +162,7 @@
                         <selected>Skin.HasSetting(home.showicons)</selected>
                         <onclick>Skin.ToggleSetting(home.showicons)</onclick>
                     </control>
-                    
+
                     <control type="radiobutton" id="9217" description="Always Show Weather Widget">
                         <width>1310</width>
                         <visible>ControlGroup(9100).HasFocus(9101)</visible>
@@ -172,7 +172,7 @@
                         <selected>Skin.HasSetting(home.showweatherfanart)</selected>
                         <onclick>Skin.ToggleSetting(home.showweatherfanart)</onclick>
                     </control>
-                    
+
                     <!-- Fanart -->
                     <control type="radiobutton" id="9223" description="Show fanart">
                         <width>1310</width>
@@ -200,7 +200,7 @@
                         <onclick>SetProperty(Dialog.1.BuiltIn,Skin.Reset(fanart.fallback))</onclick>
                         <onclick>SetProperty(Dialog.2.Label,$LOCALIZE[31271])</onclick>
                         <onclick>SetProperty(Dialog.2.BuiltIn,Skin.SetImage(fanart.fallback))</onclick>
-                        <onclick>RunScript(script.toolbox,info=selectdialog,header=$LOCALIZE[31150])</onclick> 
+                        <onclick>RunScript(script.toolbox,info=selectdialog,header=$LOCALIZE[31150])</onclick>
                     </control>
                     <control type="button" id="9229" description="Set Weather Fanart">
                         <width>1310</width>
@@ -226,7 +226,7 @@
                         <selected>Skin.HasSetting(global.showvisualisation)</selected>
                         <onclick>Skin.ToggleSetting(global.showvisualisation)</onclick>
                     </control>
-                    
+
                     <!-- OSD -->
                     <control type="radiobutton" id="9234" description="Match theme">
                         <width>1310</width>
@@ -296,9 +296,9 @@
                         <label>31217</label>
                         <selected>Skin.HasSetting(ShowClearArtOSD)</selected>
                         <onclick>Skin.ToggleSetting(ShowClearArtOSD)</onclick>
-                    </control>                    
-                    
-                    
+                    </control>
+
+
                     <!-- Furniture -->
                     <control type="radiobutton" id="9261" description="Header">
                         <width>1310</width>
@@ -392,9 +392,9 @@
                         <selected>Skin.HasSetting(furniture.overlayinfo)</selected>
                         <onclick>Skin.ToggleSetting(furniture.overlayinfo)</onclick>
                     </control>
-                    
-                    
-                    
+
+
+
                     <!-- Extras -->
                     <control type="button" id="9271" description="Startup Video">
                         <width>1310</width>
@@ -455,11 +455,11 @@
                         <onclick>Skin.ToggleSetting(home.showheader)</onclick>
                         <enable>!Skin.HasSetting(home.vertical)</enable>
                     </control>
-                    
+
                 </control>
-                
-                
-                
+
+
+
                 <!-- Lines -->
                 <control type="image">
                     <top>10</top>
@@ -469,8 +469,8 @@
                     <colordiffuse>Black12</colordiffuse>
                     <texture>common/white.png</texture>
                 </control>
-         
-                
+
+
                 <!-- Header -->
                 <control type="label">
                     <left>30</left>

--- a/1080i/SmartPlaylistEditor.xml
+++ b/1080i/SmartPlaylistEditor.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="129">
     <defaultcontrol always="true">22</defaultcontrol>
-    
+
 
     <controls>
 

--- a/1080i/SmartPlaylistRule.xml
+++ b/1080i/SmartPlaylistRule.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="129">
     <defaultcontrol always="true">9001</defaultcontrol>
-    
+
 
     <controls>
 

--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -2,9 +2,9 @@
 <!-- Foundation -->
 <window id="2005">
     <defaultcontrol>-</defaultcontrol>
-    
+
     <controls>
-        
+
         <control type="group" id="0">
             <left>0</left>
             <include>Animation.FadeIn</include>
@@ -13,7 +13,7 @@
                 <width>1920</width>
                 <height>325</height>
                 <texture colordiffuse="OSDBack" flipy="false">common/white.png</texture>
-                
+
             </control>
             <control type="grouplist">
                 <posx>20</posx>
@@ -45,7 +45,7 @@
                 </control>
             </control>
         </control>
-        
+
     </controls>
 
 </window>

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -3,7 +3,7 @@
 <window id="2901">
     <include condition="!Player.PauseEnabled">OSDFocusStop</include>
     <include condition="Player.PauseEnabled">OSDFocusPause</include>
-    
+
     <onunload>ClearProperty(osdshowinfo,home)</onunload>
     <controls>
         <control type="group">
@@ -71,9 +71,9 @@
                         <usealttexture>!VideoPlayer.SubtitlesEnabled</usealttexture>
                     </control>
                 </control>
-            
+
             </control>
-            
+
             <control type="grouplist" id="100">
                 <top>13</top>
                 <left>50</left>
@@ -86,8 +86,8 @@
                 <onright condition="Player.CanRecord + VideoPlayer.Content(LiveTV)">9003</onright>
                 <include>DefOSDUpDown</include>
                 <usecontrolcoords>true</usecontrolcoords>
-        
-                
+
+
 
                 <control type="button" id="1">
                     <description>Audio</description>
@@ -104,7 +104,7 @@
                     <onclick>ActivateWindow(123)</onclick>
                     <include>DefOSDButtons</include>
                 </control>
-                
+
                 <control type="button" id="3">
                     <onup>9302</onup>
                     <ondown>9301</ondown>
@@ -116,7 +116,7 @@
                 </control>
             </control>
             <control type="grouplist" id="101">
-            
+
                 <top>13</top>
                 <width>100%</width>
                 <height>48</height>
@@ -128,9 +128,9 @@
                 <ondown>noop</ondown>
                 <include condition="!Skin.HasSetting(osd.usetheme)">OSDVideoControls</include>
                 <include condition="Skin.HasSetting(osd.usetheme)">OSDVideoControlsFlip</include>
-            
+
             </control>
-            
+
             <control type="grouplist" id="102">
                 <top>13</top>
                 <right>50</right>
@@ -142,16 +142,16 @@
                 <onright>1</onright>
                 <include>DefOSDUpDown</include>
                 <usecontrolcoords>true</usecontrolcoords>
-                
+
                 <include condition="!VideoPlayer.Content(livetv) + [VideoPlayer.HasMenu | [!VideoPlayer.Content(movies) + !VideoPlayer.Content(episodes)]]">OSDDVDMenu</include>
                 <include condition="!VideoPlayer.HasMenu + VideoPlayer.Content(episodes)">OSDExtraInfoTV</include>
                 <include condition="!VideoPlayer.HasMenu + VideoPlayer.Content(movies)">OSDExtraInfoMOVIES</include>
-                
+
                 <include condition="!VideoPlayer.Content(livetv)">OSDVideosRight</include>
                 <include condition="VideoPlayer.Content(livetv)">OSDPVRRight</include>
             </control>
         </control>
-    
+
     </controls>
 
 </window>

--- a/1080i/VideoOSDBookmarks.xml
+++ b/1080i/VideoOSDBookmarks.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window id="125">
     <defaultcontrol always="true">2</defaultcontrol>
-    
+
 
     <controls>
         <include>GlobalOverlay</include>

--- a/1080i/View_500_Thumbnails.xml
+++ b/1080i/View_500_Thumbnails.xml
@@ -3,12 +3,12 @@
 <includes>
 
    <include name="View_500_Thumbnails">
-    
+
         <control type="group">
             <include>Animation.Common</include>
             <visible>Control.IsVisible(500)</visible>
-         
-            
+
+
             <control type="group">
                 <control type="panel" id="500">
                     <top>206</top>
@@ -146,8 +146,8 @@
                         </control>
                     </focusedlayout>
                 </control>
-                
-            
+
+
             </control>
             <include>Furniture_Scrollbar</include>
         </control>

--- a/1080i/View_503_Poster_Square.xml
+++ b/1080i/View_503_Poster_Square.xml
@@ -23,7 +23,7 @@
                 <scrolltime tween="quadratic">400</scrolltime>
                 <itemlayout width="270">
                     <control type="group">
-                        
+
                         <animation effect="Conditional" condition="true">
                             <effect type="zoom" end="60" time="0" center="213,452" />
                         </animation>
@@ -49,7 +49,7 @@
                         <control type="group">
                             <visible>!stringcompare(ListItem.Label,..)</visible>
                             <visible>stringcompare(ListItem.Overlay,OverlayWatched.png)</visible>
-                            
+
                             <control type="image">
                                 <left>379</left>
                                 <centertop>32</centertop>
@@ -96,7 +96,7 @@
                         <control type="group">
                             <visible>!stringcompare(ListItem.Label,..)</visible>
                             <visible>stringcompare(ListItem.Overlay,OverlayWatched.png)</visible>
-                          
+
                             <control type="image">
                                 <left>379</left>
                                 <centertop>32</centertop>
@@ -113,17 +113,17 @@
                             <height>PosterShadowW</height>
                             <texture border="32">common/shadow-24.png</texture>
                         </control>
-                        
+
                     </control>
                 </focusedlayout>
-    
+
             </control>
 
             <control type="group">
                 <animation effect="fade" condition="!Control.HasFocus(60)" time="200" start="100" end="0">Conditional</animation>
                 <include>Furniture_Scrollbar_Horizontal</include>
             </control>
-            
+
             <control type="grouplist">
                 <left>540</left>
                 <right>SidePad</right>
@@ -150,4 +150,4 @@
     </include>
 
 </includes>
- 
+

--- a/1080i/View_505_Wall_Square.xml
+++ b/1080i/View_505_Wall_Square.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
-<includes> 
-   
-    <include name="View_505_506_Wall">    
+<includes>
+
+    <include name="View_505_506_Wall">
         <control type="group">
             <include>Animation.Common</include>
             <visible>Control.IsVisible(505)</visible>
@@ -90,13 +90,13 @@
                         <autoscroll>false</autoscroll>
                         <label>$INFO[ListItem.Label]</label>
                     </control>
-                      
+
                 </focusedlayout>
 
             </control>
             <include>Furniture_Scrollbar</include>
             <control type="group" description="Poster">
-                
+
                 <left>SidePad</left>
                 <top>PosterPad</top>
                 <width>PosterH</width>
@@ -124,7 +124,7 @@
                     <right>20</right>
                     <top>360</top>
                     <height>300</height>
-                    
+
                     <control type="label">
                         <top>10</top>
                         <aligny>center</aligny>
@@ -154,8 +154,8 @@
                     </control>
                 </control>
             </control>
-        
-        </control>   
+
+        </control>
         <control type="group">
             <include>Animation.Common</include>
             <visible>Control.IsVisible(506)</visible>
@@ -221,22 +221,22 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
             </control>
             <include>Furniture_Scrollbar</include>
             <control type="group" description="Poster">
-                
+
                 <left>SidePad</left>
                 <top>PosterPad</top>
-             
+
                 <control type="image">
                     <centertop>PosterH</centertop>
                     <width>PosterH</width>
                     <height>48</height>
                     <aspectratio>stretch</aspectratio>
                     <texture>diffuse/shadowspot.png</texture>
-                    
+
                 </control>
                 <control type="image">
                     <width>PosterH</width>
@@ -258,9 +258,9 @@
                     <texture border="32">common/shadow-24.png</texture>
                 </control>
             </control>
-        
-        </control>  
-        
+
+        </control>
+
         <control type="group">
             <include>Animation.Common</include>
             <visible>Control.IsVisible(507)</visible>
@@ -348,13 +348,13 @@
                         <autoscroll>false</autoscroll>
                         <label>$INFO[ListItem.Label]</label>
                     </control>
-                      
+
                 </focusedlayout>
-            
+
             </control>
             <include>Furniture_Scrollbar</include>
-            
-        </control>   
+
+        </control>
 
     </include>
 

--- a/1080i/View_50_List.xml
+++ b/1080i/View_50_List.xml
@@ -144,7 +144,7 @@
                 <height>48</height>
                 <aspectratio>stretch</aspectratio>
                 <texture>diffuse/shadowspot.png</texture>
-                
+
             </control>
             <control type="image">
                 <width>PosterW</width>
@@ -166,7 +166,7 @@
                 <texture border="32">common/shadow-24.png</texture>
             </control>
         </control>
-    
+
     </include>
 
     <include name="View_50_SidePoster_Square">
@@ -189,7 +189,7 @@
                 <height>48</height>
                 <aspectratio>stretch</aspectratio>
                 <texture>diffuse/shadowspot.png</texture>
-                
+
             </control>
             <control type="image">
                 <width>PosterH</width>
@@ -287,7 +287,7 @@
                 <include>Furniture_Scrollbar</include>
             </control>
             <control type="group" description="Poster">
-                
+
                 <left>SidePad</left>
                 <top>PosterPad</top>
                 <control type="image">
@@ -305,7 +305,7 @@
                     <height>48</height>
                     <aspectratio>stretch</aspectratio>
                     <texture>diffuse/shadowspot.png</texture>
-                    
+
                 </control>
                 <control type="image">
                     <width>PosterH</width>
@@ -331,7 +331,7 @@
     </include>
     <include name="50focuslayout">
 
-        <control type="image">                                
+        <control type="image">
             <width>100%</width>
             <height>100%</height>
             <texture border="8" colordiffuse="Dark1">common/box.png</texture>
@@ -519,10 +519,10 @@
             <selectedcolor>Dark1</selectedcolor>
             <label>$INFO[ListItem.Label2]</label>
         </control>
-        
+
     </include>
     <include name="50focuslayout_square">
-        <control type="image">                                
+        <control type="image">
             <width>100%</width>
             <height>100%</height>
             <texture border="8" colordiffuse="Dark1">common/box.png</texture>

--- a/1080i/View_51_BigWide.xml
+++ b/1080i/View_51_BigWide.xml
@@ -136,7 +136,7 @@
                     <right>0</right>
                     <bottom>0</bottom>
                     <height>70</height>
-              
+
                     <control type="image">
                         <left>0</left>
                         <right>0</right>
@@ -201,12 +201,12 @@
                         <visible>!Container.Content(seasons)</visible>
                     </control>
                 </control>
-            
+
             </control>
             <include>Furniture_Scrollbar_Horizontal</include>
         </control>
     </include>
-    
+
     <include name="View_51_BigWide">
         <description>List View (id=51)</description>
         <control type="group">
@@ -217,7 +217,7 @@
                 <left>70</left>
                 <right>70</right>
                 <height>660</height>
-                
+
                 <!-- Item -3 -->
                 <control type="group">
                     <top>10</top>
@@ -283,7 +283,7 @@
                         <fadetime>800</fadetime>
                         <texture background="true" diffuse="diffuse/bigwideside.png" colordiffuse="ff444444">$INFO[ListItem(-2).Art(fanart)]</texture>
                     </control>
-               
+
                     <control type="label">
                         <posx>30</posx>
                         <posy>550</posy>
@@ -437,7 +437,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture>$VAR[PercentWatchedP2]</texture>
                         <visible>!stringcompare(ListItem(2).Label,..)</visible>
-                        
+
                     </control>
                 </control>
 
@@ -482,10 +482,10 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture>$VAR[PercentWatchedN3]</texture>
                         <visible>!stringcompare(ListItem(-3).Label,..)</visible>
-                        
+
                     </control>
                 </control>
-                
+
             </control>
             <control type="group">
                 <top>216</top>
@@ -524,7 +524,7 @@
                             <texture background="true" diffuse="diffuse/bigwiderolodex.png">$VAR[FanartImage]</texture>
                         </control>
                     </itemlayout>
-                   
+
                     <focusedlayout height="640" width="1138">
                         <control type="image">
                             <centerleft>50%</centerleft>
@@ -541,7 +541,7 @@
                     <right>0</right>
                     <bottom>0</bottom>
                     <height>70</height>
-              
+
                     <control type="image">
                         <left>0</left>
                         <right>0</right>
@@ -606,7 +606,7 @@
                         <visible>!Container.Content(seasons)</visible>
                     </control>
                 </control>
-            
+
             </control>
             <include>Furniture_Scrollbar_Horizontal</include>
         </control>
@@ -649,7 +649,7 @@
                     <texture background="true" diffuse="diffuse/lovefilm.png">$VAR[FanartImage]</texture>
                 </control>
             </itemlayout>
-           
+
             <focusedlayout height="640" width="1760">
                 <control type="image">
                     <centerleft>50%</centerleft>
@@ -662,5 +662,5 @@
             </focusedlayout>
         </control>
     </include>
-    
+
 </includes>

--- a/1080i/View_52_BigList.xml
+++ b/1080i/View_52_BigList.xml
@@ -182,4 +182,4 @@
     </include>
 
 </includes>
- 
+

--- a/1080i/View_53_Poster.xml
+++ b/1080i/View_53_Poster.xml
@@ -19,7 +19,7 @@
         <scrolltime tween="quadratic">400</scrolltime>
         <itemlayout width="270">
             <control type="group">
-                
+
                 <animation effect="Conditional" condition="true">
                     <effect type="zoom" end="60" time="0" center="213,452" />
                 </animation>
@@ -38,7 +38,7 @@
                     <aspectratio>stretch</aspectratio>
                     <texture>diffuse/shadowspot.png</texture>
                 </control>
-               
+
                 <control type="image">
                     <width>PosterW</width>
                     <height>PosterH</height>
@@ -47,7 +47,7 @@
                 </control>
                 <control type="group">
                     <visible>!stringcompare(ListItem.Label,..)</visible>
-                    
+
                     <control type="image">
                         <left>379</left>
                         <centertop>32</centertop>
@@ -103,8 +103,8 @@
                 </control>
                 <control type="group">
                     <visible>!stringcompare(ListItem.Label,..)</visible>
-                    
-                  
+
+
                   <control type="image">
                         <left>379</left>
                         <centertop>32</centertop>
@@ -129,7 +129,7 @@
                     <height>PosterShadowH</height>
                     <texture border="32">common/shadow-24.png</texture>
                 </control>
-                
+
             </control>
         </focusedlayout>
     </include>
@@ -142,13 +142,13 @@
             <visible>Control.IsVisible(53)</visible>
             <include condition="!Skin.HasSetting(53poster.nowrap)">53Wrap</include>
             <include condition="Skin.HasSetting(53poster.nowrap)">53Fixed</include>
-            
+
             <control type="group">
                 <animation effect="fade" condition="!Control.HasFocus(60)" time="200" start="100" end="0">Conditional</animation>
                 <include>Furniture_Scrollbar_Horizontal</include>
             </control>
-            
-            
+
+
             <control type="grouplist">
                 <left>540</left>
                 <right>SidePad</right>
@@ -182,4 +182,4 @@
     </include>
 
 </includes>
- 
+

--- a/1080i/View_54_Banner.xml
+++ b/1080i/View_54_Banner.xml
@@ -3,7 +3,7 @@
 <includes>
 
    <include name="View_54_Banner">
-    
+
         <control type="group">
             <include>Animation.Common</include>
             <visible>Control.IsVisible(54)</visible>
@@ -119,11 +119,11 @@
                             </control>
                         </control>
                     </itemlayout>
-                    
+
                     <itemlayout width="1140" height="106" condition="Container.Content(albums)">
                         <control type="group">
                             <posy>-35</posy>
-                          
+
                             <control type="label">
                                 <top>47</top>
                                 <left>320</left>
@@ -219,7 +219,7 @@
                         </control>
                     </itemlayout>
 
-                    
+
                     <focusedlayout width="1288" height="330" condition="!Container.Content(episodes) + !Container.Content(albums) + !Container.Content(songs) + Skin.HasSetting(54banner.showinfo)">
                         <control type="image">
                             <left>110</left>
@@ -228,7 +228,7 @@
                             <bottom>10</bottom>
                             <texture colordiffuse="Dark1" border="5">common/box.png</texture>
                         </control>
-                        <control type="image">                                
+                        <control type="image">
                             <left>110</left>
                             <top>10</top>
                             <width>207</width>
@@ -339,8 +339,8 @@
                                 <textcolor>Light1</textcolor>
                             </control>
                         </control>
-                        
-                        
+
+
                         <control type="label">
                             <centerbottom>48</centerbottom>
                             <left>44</left>
@@ -366,7 +366,7 @@
                             <selectedcolor>Light1</selectedcolor>
                             <visible>!Container.Content(seasons)</visible>
                         </control>
-                        
+
                     </focusedlayout>
                     <focusedlayout width="1560" height="322" condition="Container.Content(episodes)">
                         <control type="group">
@@ -392,7 +392,7 @@
                                 <texture diffuse="diffuse/banner.png" background="true">$VAR[FanartImage]</texture>
                                 <aspectratio scalediffuse="false">scale</aspectratio>
                             </control>
-                            
+
                             <control type="label">
                                 <font>EpisodeNumber</font>
                                 <top>15</top>
@@ -479,7 +479,7 @@
                                 <texture diffuse="diffuse/banner.png" background="true">$VAR[MusicImage]</texture>
                                 <aspectratio scalediffuse="false">scale</aspectratio>
                             </control>
-                    
+
                             <control type="label">
                                 <top>47</top>
                                 <left>320</left>
@@ -516,7 +516,7 @@
                                 <textcolor>Light1</textcolor>
                                 <selectedcolor>Light1</selectedcolor>
                             </control>
-                            
+
                         </control>
                     </focusedlayout>
                     <focusedlayout width="1140" height="322" condition="Container.Content(songs)">
@@ -655,9 +655,9 @@
                             </control>
                         </control>
                     </focusedlayout>
-                
+
                 </control>
-                
+
                 <include>Furniture_Scrollbar</include>
             </control>
         </control>

--- a/1080i/View_55_Wall.xml
+++ b/1080i/View_55_Wall.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <includes>
-    <include name="View_55_Wall_Poster">    
+    <include name="View_55_Wall_Poster">
         <control type="group">
             <include>Animation.Common</include>
             <visible>Control.IsVisible(55)</visible>
@@ -77,7 +77,7 @@
                         <height>32</height>
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
-                        
+
                         <visible>!stringcompare(ListItem.Label,..)</visible>
                     </control>
                     <control type="image">
@@ -88,7 +88,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture>$VAR[PosterPercentWatched]</texture>
                         <visible>!stringcompare(ListItem.Label,..)</visible>
-                        
+
                     </control>
                     <control type="image">
                         <left>5</left>
@@ -105,12 +105,12 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
             </control>
             <include>Furniture_Scrollbar</include>
             <include>View_50_SidePoster</include>
-        </control>   
+        </control>
     </include>
 
 
@@ -153,7 +153,7 @@
                         <height>32</height>
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
-                        
+
                         <visible>!stringcompare(ListItem.Label,..)</visible>
                     </control>
                     <control type="image">
@@ -164,7 +164,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture>$VAR[PosterPercentWatched]</texture>
                         <visible>!stringcompare(ListItem.Label,..)</visible>
-                        
+
                     </control>
                 </itemlayout>
                 <focusedlayout height="330" width="227">
@@ -189,7 +189,7 @@
                         <height>32</height>
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
-                        
+
                         <visible>!stringcompare(ListItem.Label,..)</visible>
                     </control>
                         <control type="image">
@@ -200,7 +200,7 @@
                             <aspectratio aligny="top">keep</aspectratio>
                             <texture>$VAR[PosterPercentWatched]</texture>
                             <visible>!stringcompare(ListItem.Label,..)</visible>
-                            
+
                         </control>
                         <control type="image">
                             <left>3</left>
@@ -220,16 +220,16 @@
                     </control>
                 </focusedlayout>
             </control>
-            
+
             <include>Furniture_Scrollbar</include>
-            
+
             <include content="Fanart_Info">
                 <param name="posx" value="70" />
             </include>
         </control>
     </include>
-        
-    <include name="View_55_Wall">    
+
+    <include name="View_55_Wall">
         <control type="group">
             <include>Animation.Common</include>
             <visible>Control.IsVisible(55)</visible>
@@ -270,7 +270,7 @@
                         <height>32</height>
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
-                        
+
                         <visible>!stringcompare(ListItem.Label,..)</visible>
                     </control>
                     <control type="image">
@@ -281,7 +281,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture>$VAR[PosterPercentWatched]</texture>
                         <visible>!stringcompare(ListItem.Label,..)</visible>
-                        
+
                     </control>
                 </itemlayout>
                 <focusedlayout height="337" width="222">
@@ -307,7 +307,7 @@
                         <height>32</height>
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
-                        
+
                         <visible>!stringcompare(ListItem.Label,..)</visible>
                     </control>
                     <control type="image">
@@ -318,7 +318,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture>$VAR[PosterPercentWatched]</texture>
                         <visible>!stringcompare(ListItem.Label,..)</visible>
-                        
+
                     </control>
                     <control type="image">
                         <left>3</left>
@@ -335,12 +335,12 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
             </control>
             <include>Furniture_Scrollbar</include>
-            
-        </control>   
+
+        </control>
     </include>
 
     <include name="View_555_Wall_Episodes">

--- a/1080i/View_56_MediaInfo.xml
+++ b/1080i/View_56_MediaInfo.xml
@@ -40,7 +40,7 @@
                 <include>Furniture_Scrollbar</include>
             </control>
             <control type="group" description="Poster">
-                
+
                 <left>SidePad</left>
                 <top>PosterPad</top>
                 <control type="image">
@@ -58,7 +58,7 @@
                     <height>48</height>
                     <aspectratio>stretch</aspectratio>
                     <texture>diffuse/shadowspot.png</texture>
-                    
+
                 </control>
                 <control type="image">
                     <width>PosterW</width>
@@ -153,11 +153,11 @@
                 <include>Furniture_Scrollbar</include>
             </control>
             <include>View_50_SidePoster</include>
-            
+
             <include content="Fanart_Info">
                 <param name="posx" value="1205" />
             </include>
-            
+
         </control>
     </include>
     <include name="View_56_MediaInfo3">
@@ -217,9 +217,9 @@
             </include>
         </control>
     </include>
-    
+
     <include name="56focuslayout">
-        <control type="image">                                
+        <control type="image">
             <width>100%</width>
             <height>100%</height>
             <texture border="8" colordiffuse="Dark1">common/box.png</texture>
@@ -288,6 +288,6 @@
             <label>$INFO[ListItem.Label2]</label>
         </control>
     </include>
-    
+
 
 </includes>

--- a/1080i/View_57_ExtraInfo.xml
+++ b/1080i/View_57_ExtraInfo.xml
@@ -112,7 +112,7 @@
                 <right>12</right>
                 <posy>319</posy>
                 <height>330</height>
-                
+
                 <control type="label">
                     <top>10</top>
                     <aligny>center</aligny>
@@ -141,7 +141,7 @@
                     <label>$VAR[LabelPlotBox]</label>
                 </control>
             </control>
-        
+
         </control>
     </include>
     <include name="Fanart_Info">
@@ -159,7 +159,7 @@
                     <height>100%</height>
                     <texture border="10">common/nofocus-shadow10.png</texture>
                 </control>
-             
+
                 <control type="image">
                     <left>10</left>
                     <top>10</top>
@@ -175,7 +175,7 @@
                 <right>20</right>
                 <posy>370</posy>
                 <height>290</height>
-                
+
                 <control type="label">
                     <top>8</top>
                     <aligny>center</aligny>
@@ -204,10 +204,10 @@
                     <label>$VAR[LabelPlotBox]</label>
                 </control>
             </control>
-        
+
         </control>
-        
+
     </include>
 
-    
+
 </includes>

--- a/1080i/View_58_Cards.xml
+++ b/1080i/View_58_Cards.xml
@@ -39,7 +39,7 @@
                             <texture>$VAR[PercentWatched]</texture>
                             <visible>!stringcompare(ListItem.Label,..)</visible>
                         </control>
-                        <control type="image">                                
+                        <control type="image">
                             <left>10</left>
                             <top>10</top>
                             <width>207</width>
@@ -82,7 +82,7 @@
                             <selectedcolor>Dark1</selectedcolor>
                             <label fallback="19055">$VAR[LabelYear,,  •  ]$VAR[LabelDuration,,  •  ]$INFO[ListItem.Rating]</label>
                         </control>
-                       
+
                     </itemlayout>
 
                     <itemlayout width="890" height="330" condition="Container.Content(episodes)">
@@ -102,7 +102,7 @@
                             <texture>$VAR[PercentWatched]</texture>
                             <visible>!stringcompare(ListItem.Label,..)</visible>
                         </control>
-                        <control type="image">                                
+                        <control type="image">
                             <left>10</left>
                             <top>10</top>
                             <width>400</width>
@@ -144,7 +144,7 @@
                             <selectedcolor>Dark1</selectedcolor>
                             <label fallback="19055">$VAR[LabelYear,,  •  ]$VAR[LabelDuration,,  •  ]$INFO[ListItem.Rating]</label>
                         </control>
-                       
+
                     </itemlayout>
 
                     <focusedlayout width="890" height="330" condition="!Container.Content(episodes)">
@@ -155,7 +155,7 @@
                             <bottom>10</bottom>
                             <texture colordiffuse="Dark1" border="5">common/box.png</texture>
                         </control>
-                        <control type="image">                                
+                        <control type="image">
                             <left>10</left>
                             <top>10</top>
                             <width>207</width>
@@ -224,7 +224,7 @@
                             <texture>$VAR[PercentWatched]</texture>
                             <visible>!stringcompare(ListItem.Label,..)</visible>
                         </control>
-                        <control type="image">                                
+                        <control type="image">
                             <left>10</left>
                             <top>10</top>
                             <width>400</width>
@@ -266,14 +266,14 @@
                             <selectedcolor>Light1</selectedcolor>
                             <label fallback="19055">$VAR[LabelYear,,  •  ]$VAR[LabelDuration,,  •  ]$INFO[ListItem.Rating]</label>
                         </control>
-                       
+
                     </focusedlayout>
                 </control>
                 <include>Furniture_Scrollbar</include>
             </control>
-        
+
         </control>
     </include>
-   
+
 
 </includes>

--- a/1080i/View_59_BannerWall.xml
+++ b/1080i/View_59_BannerWall.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <includes>
-  
-    <include name="View_59_BannerWall">    
+
+    <include name="View_59_BannerWall">
         <control type="group">
             <include>Animation.Common</include>
             <visible>Control.IsVisible(59)</visible>
@@ -36,7 +36,7 @@
                         <aspectratio scalediffuse="false">scale</aspectratio>
                         <texture diffuse="diffuse/wall-fanart.png" background="true">$VAR[BannerImage]</texture>
                     </control>
-                    
+
                     <control type="image">
                         <centerright>32</centerright>
                         <centertop>38</centertop>
@@ -45,7 +45,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
                         <visible>!stringcompare(ListItem.Label,..)</visible>
-                        
+
                     </control>
                     <control type="image">
                         <centerright>32</centerright>
@@ -55,7 +55,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture>$VAR[PosterPercentWatched]</texture>
                         <visible>!stringcompare(ListItem.Label,..)</visible>
-                        
+
                     </control>
                 </itemlayout>
                 <focusedlayout height="133" width="593">
@@ -74,7 +74,7 @@
                         <aspectratio scalediffuse="false">scale</aspectratio>
                         <texture diffuse="diffuse/wall-fanart.png" background="true">$VAR[BannerImage]</texture>
                     </control>
-                    
+
                     <control type="image">
                         <centerright>32</centerright>
                         <centertop>38</centertop>
@@ -83,7 +83,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture colordiffuse="$VAR[ColorHighlight]">$VAR[PosterPercentWatchedBacking]</texture>
                         <visible>!stringcompare(ListItem.Label,..)</visible>
-                        
+
                     </control>
                     <control type="image">
                         <centerright>32</centerright>
@@ -93,7 +93,7 @@
                         <aspectratio aligny="top">keep</aspectratio>
                         <texture>$VAR[PosterPercentWatched]</texture>
                         <visible>!stringcompare(ListItem.Label,..)</visible>
-                        
+
                     </control>
                     <control type="image">
                         <left>3</left>
@@ -110,11 +110,11 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
             </control>
             <include>Furniture_Scrollbar</include>
-            
-        </control>   
+
+        </control>
     </include>
 </includes>

--- a/1080i/script-NextAired-TVGuide.xml
+++ b/1080i/script-NextAired-TVGuide.xml
@@ -1,7 +1,7 @@
 <window type="dialog">
     <defaultcontrol always="true">9500</defaultcontrol>
     <backgroundcolor>0</backgroundcolor>
-    
+
     <controls>
         <include>GlobalBackground</include>
         <include>Furniture_Header</include>
@@ -52,6 +52,6 @@
                 <param name="onright" value="200" />
             </include>
         </control>
-        
+
     </controls>
 </window>

--- a/1080i/script-NextAired-TVGuide2.xml
+++ b/1080i/script-NextAired-TVGuide2.xml
@@ -1,7 +1,7 @@
 <window type="dialog">
     <defaultcontrol always="true">9500</defaultcontrol>
     <backgroundcolor>0</backgroundcolor>
-    
+
     <controls>
         <include>GlobalBackground</include>
         <include>Furniture_Header</include>
@@ -97,6 +97,6 @@
                 <param name="onright" value="200" />
             </include>
         </control>
-        
+
     </controls>
 </window>

--- a/1080i/script-cu-lrclyrics-main.xml
+++ b/1080i/script-cu-lrclyrics-main.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-    
+
     <zorder>1</zorder>
     <controls>
         <control type="group">
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
             <control type="group">
-    
+
                 <control type="group">
                     <animation effect="slide" end="334" start="0" time="75" tween="quadratic" condition="Window.IsActive(musicosd)">Conditional</animation>
                     <top>200</top>
                     <bottom>180</bottom>
                     <width>100%</width>
-                    
+
                     <!-- ** Required ** Do not change <id> or <type> (Smooth scrolling list for lyrics) -->
                     <control type="list" id="110">
                         <left>350</left>
@@ -78,16 +78,16 @@
                             </control>
                         </focusedlayout>
                     </control>
-                    
+
                     <control type="label" id="200">
                         <description>Scraper label</description>
                         <visible>false</visible>
                     </control>
-                
+
                 </control>
-              
+
             </control>
-       
+
         </control>
     </controls>
 </window>

--- a/1080i/script-globalsearch-infodialog.xml
+++ b/1080i/script-globalsearch-infodialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window type="dialog">
     <defaultcontrol always="true">9401</defaultcontrol>
-    
+
 
     <controls>
         <control type="list" id="100">
@@ -28,7 +28,7 @@
         </control>
 
         <control type="group">
-            <control type="group" id="110">              
+            <control type="group" id="110">
             </control>
             <control type="group" id="120">
             </control>

--- a/1080i/script-globalsearch-main.xml
+++ b/1080i/script-globalsearch-main.xml
@@ -14,7 +14,7 @@
             <include>Furniture_Weather</include>
         </control>
         <control type="group" id="100">
-            
+
             <control type="group">
                 <!-- <visible>!Window.IsVisible(script-globalsearch-infodialog.xml)</visible>-->
                 <visible>!Window.IsVisible(script-script.extendedinfo-VideoList.xml) + !Window.IsVisible(DialogAddonInfo.xml) + !Window.IsVisible(DialogPVRRecordingInfo.xml) + !Window.IsVisible(DialogPVRGuideInfo.xml) + !Window.IsVisible(DialogMusicInfo.xml) + !Window.IsVisible(DialogVideoInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogVideoInfo.xml)</visible>
@@ -60,12 +60,12 @@
                         <animation effect="fade" end="100" start="0" delay="300" time="400" reversible="false">Visible</animation>
                     </control>
                 </control>
-                
+
                 <control type="scrollbar" id="60">
                     <left>-1000</left>
                     <animation effect="fade" start="100" end="0" time="400" condition="true">Conditional</animation>
                 </control>
-    
+
                 <control type="grouplist" id="9500">
                     <posy>0</posy>
                     <height>660</height>
@@ -173,7 +173,7 @@
                         <param name="onleft" value="171" />
                         <param name="onright" value="211" />
                     </include>
-                    
+
                 </control>
             </control>
         </control>
@@ -216,6 +216,6 @@
         <control type="label" id="199">
             <visible>false</visible>
         </control>
-        
+
     </controls>
 </window>

--- a/1080i/script-script.extendedinfo-DialogInfo.xml
+++ b/1080i/script-script.extendedinfo-DialogInfo.xml
@@ -2,12 +2,12 @@
 <!-- Foundation -->
 <window>
     <defaultcontrol always="true">9000</defaultcontrol>
-      
+
     <onload>SetProperty(150_onback,SetFocus(9000))</onload>
     <onload>SetProperty(250_onback,SetFocus(9000))</onload>
     <onload>SetProperty(350_onback,SetFocus(9000))</onload>
     <onload>SetProperty(550_onback,SetFocus(9000))</onload>
-    <onload>ClearProperty(content)</onload>  
+    <onload>ClearProperty(content)</onload>
     <onload>Dialog.Close(2003)</onload>
     <controls>
         <control type="image">
@@ -45,7 +45,7 @@
                         <height>48</height>
                         <aspectratio>stretch</aspectratio>
                         <texture>diffuse/shadowspot.png</texture>
-                        
+
                     </control>
                     <control type="image">
                         <width>PosterW</width>
@@ -75,7 +75,7 @@
                 <animation effect="slide" start="0" end="1920" time="300" tween="quadratic" easing="in">WindowClose</animation>
                 <animation effect="slide" start="1920" end="0" delay="0" time="300" tween="quadratic" easing="out">Visible</animation>
                 <animation effect="slide" start="0" end="1920" time="300" tween="quadratic" easing="in">Hidden</animation>
-          
+
                 <!-- Arrows -->
                 <control type="group">
                     <include>Animation.DelayFadeIn</include>
@@ -139,7 +139,7 @@
                         <include>DefInfoButtons</include>
                         <onclick>SetProperty(content,550)</onclick>
                         <onclick>SetFocus(550)</onclick>
-                    </control>  
+                    </control>
                 </control>
 
                 <control type="label">
@@ -370,9 +370,9 @@
                                 <aligny>center</aligny>
                             </control>
                         </control>
-                        
-                        
-                      
+
+
+
                         <control type="label">
                             <width>100%</width>
                             <height>36</height>
@@ -390,7 +390,7 @@
                             <align>justify</align>
                             <label>$INFO[Window.Property(Biography)]</label>
                         </control>
-                        
+
                     </control>
                 </control>
 
@@ -411,7 +411,7 @@
                     <onleft>350</onleft>
                     <onright>350</onright>
                     <include>DefExtendedInfoListWide</include>
-                </control>                
+                </control>
                 <control type="list" id="450"><visible>false</visible></control>
                 <control type="list" id="550">
                     <visible allowhiddenfocus="true">StringCompare(Window.Property(content),550)</visible>

--- a/1080i/script-script.extendedinfo-DialogVideoInfo.xml
+++ b/1080i/script-script.extendedinfo-DialogVideoInfo.xml
@@ -2,7 +2,7 @@
 <!-- Foundation -->
 <window>
     <defaultcontrol always="true">9000</defaultcontrol>
-    
+
     <onload>SetProperty(150_onback,SetFocus(9000))</onload>
     <onload>SetProperty(350_onback,SetFocus(9000))</onload>
     <onload>SetProperty(750_onback,SetFocus(9000))</onload>
@@ -22,7 +22,7 @@
             <animation type="Conditional" reversible="true" condition="Window.IsVisible(FileBrowser.xml) | Window.IsVisible(DialogConfirm.xml) | Window.IsVisible(DialogSelect.xml) | Window.IsVisible(DialogContextMenu.xml) | Window.IsVisible(DialogButtonMenu.xml)">
                 <effect type="zoom" end="95" start="100" time="200" center="auto" tween="quadratic" easing="in" />
             </animation>
-      
+
             <!-- Side Poster -->
             <control type="group">
                 <animation effect="slide" start="-1920" end="0" delay="300" time="300" tween="quadratic" easing="out">WindowOpen</animation>
@@ -47,7 +47,7 @@
                         <height>48</height>
                         <aspectratio>stretch</aspectratio>
                         <texture>diffuse/shadowspot.png</texture>
-                        
+
                     </control>
                     <control type="image">
                         <width>PosterW</width>
@@ -77,7 +77,7 @@
                 <animation effect="slide" start="0" end="1920" time="300" tween="quadratic" easing="in">WindowClose</animation>
                 <animation effect="slide" start="1920" end="0" delay="0" time="300" tween="quadratic" easing="out">Visible</animation>
                 <animation effect="slide" start="0" end="1920" time="300" tween="quadratic" easing="in">Hidden</animation>
-          
+
                 <control type="group">
                     <include>Animation.DelayFadeIn</include>
                     <visible>!IsEmpty(Window.Property(content))</visible>
@@ -142,7 +142,7 @@
                         <include>DefInfoButtons</include>
                         <onclick>SetProperty(content,150)</onclick>
                         <onclick>SetFocus(150)</onclick>
-                        
+
                     </control>
                     <control type="button" id ="9004">
                         <description>Youtube</description>
@@ -157,7 +157,7 @@
                         <include>DefInfoButtons</include>
                         <onclick>SetProperty(content,750)</onclick>
                         <onclick>SetFocus(750)</onclick>
-                    </control>  
+                    </control>
                 </control>
 
                 <!-- List Headers -->
@@ -463,7 +463,7 @@
                                 <aligny>center</aligny>
                             </control>
                         </control>
-                      
+
                         <control type="label">
                             <width>100%</width>
                             <height>36</height>
@@ -481,7 +481,7 @@
                             <align>justify</align>
                             <label>$INFO[Window.Property(plot)]</label>
                         </control>
-                        
+
                     </control>
                 </control>
 

--- a/1080i/script-script.extendedinfo-T9Search.xml
+++ b/1080i/script-script.extendedinfo-T9Search.xml
@@ -12,7 +12,7 @@
 
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
-            
+
             <control type="image">
                 <left>-8</left>
                 <right>-8</right>

--- a/1080i/script-script.extendedinfo-VideoList.xml
+++ b/1080i/script-script.extendedinfo-VideoList.xml
@@ -109,7 +109,7 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
             </control>
             <control type="scrollbar" id="60">
@@ -133,7 +133,7 @@
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>
                 <visible allowhiddenfocus="true">ControlGroup(9000).HasFocus()</visible>
-            
+
                 <control type="grouplist" id="9000">
                     <top>0</top>
                     <bottom>0</bottom>
@@ -223,8 +223,8 @@
                     </control>
                 </control>
             </control>
-            
-        </control> 
+
+        </control>
         <control type="button" id="600">
             <onfocus>SetFocus(500)</onfocus>
             <width>1</width>
@@ -237,6 +237,6 @@
             <height>1</height>
             <posx>-1000</posx>
         </control>
-       
+
     </controls>
 </window>

--- a/1080i/script-script.extendedinfo-YoutubeList.xml
+++ b/1080i/script-script.extendedinfo-YoutubeList.xml
@@ -32,7 +32,7 @@
             <visible>!Window.IsVisible(script-globalsearch-main.xml) + !Window.IsVisible(script-globalsearch-infodialog.xml) + !Window.IsVisible(DialogAddonInfo.xml) + !Window.IsVisible(DialogPVRRecordingInfo.xml) + !Window.IsVisible(DialogPVRGuideInfo.xml) + !Window.IsVisible(DialogMusicInfo.xml) + !Window.IsVisible(DialogVideoInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogVideoInfo.xml)</visible>
             <visible>Control.IsVisible(500)</visible>
 
-            
+
 
             <animation type="Conditional" reversible="true" condition="ControlGroup(9000).HasFocus()">
                 <effect type="slide" end="444" start="0" time="200" tween="quadratic"/>
@@ -215,7 +215,7 @@
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>
                 <visible allowhiddenfocus="true">ControlGroup(9000).HasFocus()</visible>
-            
+
                 <control type="grouplist" id="9000">
                     <top>0</top>
                     <bottom>0</bottom>
@@ -294,8 +294,8 @@
                     </control>
                 </control>
             </control>
-            
-        </control> 
+
+        </control>
         <control type="button" id="600">
             <onfocus>SetFocus(500)</onfocus>
             <width>1</width>

--- a/1080i/script-skinshortcuts.xml
+++ b/1080i/script-skinshortcuts.xml
@@ -28,7 +28,7 @@
                 <align>left</align>
                 <textcolor>Black70</textcolor>
             </control>
-            
+
             <!-- Left List: Current Shortcuts -->
             <control type="list" id="211">
                 <description>Rules List Control</description>
@@ -151,9 +151,9 @@
                     <texturenofocus colordiffuse="Black30" flipy="true">buttons/moveup.png</texturenofocus>
                     <texturefocus colordiffuse="Selected" flipy="true">buttons/moveup.png</texturefocus>
                 </control>
-                
+
             </control>
-            
+
             <!-- Right Buttons -->
             <control type="grouplist" id="9100">
                 <onleft>304</onleft>
@@ -166,9 +166,9 @@
                 <height>552</height>
                 <orientation>vertical</orientation>
                 <itemgap>3</itemgap>
-                
-                
-                
+
+
+
                 <control type="button" id="401" description="Alt chooser">
                     <width>100%</width>
                     <height>66</height>
@@ -194,7 +194,7 @@
                     <align>left</align>
                     <include>DefDialogButtons</include>
                 </control>
-                
+
                 <control type="button" id="312" description="Widget">
                     <width>100%</width>
                     <height>66</height>
@@ -296,7 +296,7 @@
                     <param name="buttonid1" value="9309" />
                     <param name="buttonid2" value="9509" />
                 </include>
-               
+
                 <control type="button" id="308" description="Reset">
                     <width>100%</width>
                     <height>66</height>
@@ -305,9 +305,9 @@
                     <include>DefDialogButtons</include>
                 </control>
             </control>
-        
-            
-           
+
+
+
         </control>
         <control type="button" id="404"><visible allowhiddenfocus="true">false</visible></control>
     </controls>

--- a/1080i/script-videoextras-main.xml
+++ b/1080i/script-videoextras-main.xml
@@ -5,13 +5,13 @@
     <onload condition="IsEmpty(ListItem.TvShowTitle)">SetProperty("TvTunesSupported", "Movies")</onload>
     <onload condition="Skin.HasSetting(ActivateTvTunes) + System.HasAddon(script.tvtunes)">XBMC.RunScript(script.tvtunes,backend=True)</onload>
     <defaultcontrol always="true">51</defaultcontrol>
-    
+
     <controls>
         <include>GlobalBackground</include>
         <control type="group">
             <height>866</height>
             <include>DefDialogInfoPanel</include>
-            
+
             <control type="label">
                 <description>Header Label</description>
                 <centerleft>50%</centerleft>
@@ -21,7 +21,7 @@
                 <posy>15</posy>
                 <font>MediumBold</font>
             </control>
-  
+
             <control type="list" id="51">
                 <description>Control Area</description>
                 <left>15</left>
@@ -51,10 +51,10 @@
                         <font>Small</font>
                         <label>$INFO[ListItem.Label2]</label>
                     </control>
-                
+
                 </itemlayout>
                 <focusedlayout width="1260" height="69">
-                    <control type="image">                                
+                    <control type="image">
                         <width>100%</width>
                         <height>100%</height>
                         <texture border="8" colordiffuse="$VAR[ColorHighlight]">common/box.png</texture>

--- a/1080i/service-LibreELEC-Settings-mainWindow.xml
+++ b/1080i/service-LibreELEC-Settings-mainWindow.xml
@@ -44,7 +44,7 @@
                 <pagecontrol>-</pagecontrol>
                 <scrolltime>300</scrolltime>
                 <itemlayout height="75" width="396">
- 
+
                     <control type="label">
                         <left>85</left>
 			<align>center</align>

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,7 @@ DialogSettings fixes (Loggio)
 
 [B]2.3.3[/B]
 Fix mutebug
-Updates to vertical home screen 
+Updates to vertical home screen
 - scroll over when widget focused
 - larger font for selected menu item
 Fix widget targets
@@ -20,7 +20,7 @@ Fix widget targets
 [B]2.3.0[/B]
 Krypton work begins:
 Rename DialogProgress to DialogConfirm and add Yes button
-Remove DialogOK DialogYesNo	
+Remove DialogOK DialogYesNo
 Fix Slider(ex) orientation
 Rename DialogKaiToast to DialogNotification
 Fix DialogAudioDSPManager
@@ -482,7 +482,7 @@ Busy indicator switched to gif flower bloom
 
 [B]1.0.8[/B]
 New director info screen.
-Add themoviedb.org In Cinemas window 
+Add themoviedb.org In Cinemas window
  - ActivateWindow(3204)
 Add the moviedv.org Airing window
  - ActivateWindow(3205)
@@ -685,7 +685,7 @@ Startup video option
 Startup screen
 Fix busy dialog
 Fix for thumbs view
-Fix osd guide/channels 
+Fix osd guide/channels
 Fix fullscreen codec info colour
 Fix pvrosdguide selected and icon
 
@@ -733,7 +733,7 @@ Hide weather/nextrec widgets onup
 Fix missing codec info
 
 [B]0.9.12[/B]
-Global Search 
+Global Search
 Next Aired
 
 [B]0.9.11[/B]

--- a/colors/Dark with Dark Dialogs.xml
+++ b/colors/Dark with Dark Dialogs.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<colors> 
+<colors>
     <color name="Black100">FFdddddd</color>
     <color name="Black70">B3dddddd</color>
     <color name="Black30">4Ddddddd</color>
     <color name="Black12">1F000000</color>
-    
+
     <color name="White100">FF333333</color>
     <color name="White70">B3333333</color>
     <color name="White30">4D333333</color>
     <color name="White12">1F333333</color>
-    
+
     <color name="Dark1">ffcccccc</color>
     <color name="Dark2">b3cccccc</color>
     <color name="Dark3">4dcccccc</color>
@@ -18,7 +18,7 @@
     <color name="Light2">b3333333</color>
     <color name="Light3">4d333333</color>
     <color name="Light4">1f333333</color>
-    
+
     <color name="Background">ff181818</color>
     <color name="FanartFade">2Fffffff</color>
     <color name="FloorFade">BF181818</color>

--- a/colors/Dark with Light Dialogs.xml
+++ b/colors/Dark with Light Dialogs.xml
@@ -13,12 +13,12 @@
     <color name="White70">B3cccccc</color>
     <color name="White30">4Dcccccc</color>
     <color name="White12">1Fcccccc</color>
-    
+
     <color name="Black100">FF000000</color>
     <color name="Black70">B3000000</color>
     <color name="Black30">4D000000</color>
     <color name="Black12">1F000000</color>
-    
+
     <color name="Background">ff181818</color>
     <color name="FanartFade">2Fffffff</color>
     <color name="FloorFade">BF181818</color>

--- a/colors/Light with Dark Dialogs.xml
+++ b/colors/Light with Dark Dialogs.xml
@@ -11,29 +11,29 @@
     <color name="Light2">b3dddddd</color>
     <color name="Light3">4ddddddd</color>
     <color name="Light4">1fdddddd</color>
-    
+
     <color name="Background">ffdddddd</color>
     <color name="FanartFade">2Fffffff</color>
     <color name="FloorFade">BBdddddd</color>
-    
+
     <color name="OSDBack">df000000</color>
     <color name="Panel">FF333333</color>
-    
+
     <color name="PanelWhite100">FFdddddd</color>
     <color name="PanelWhite70">B3dddddd</color>
     <color name="PanelWhite30">4Ddddddd</color>
     <color name="PanelWhite12">1Fdddddd</color>
     <color name="PanelBlack30">4D000000</color>
-    
+
     <color name="Black100">FFdddddd</color>
     <color name="Black70">B3dddddd</color>
     <color name="Black30">4Ddddddd</color>
     <color name="Black12">1F000000</color>
-    
+
     <color name="White100">FF333333</color>
     <color name="White70">B3333333</color>
     <color name="White30">4D333333</color>
     <color name="White12">1F333333</color>
-    
-    
+
+
 </colors>

--- a/colors/Light with Light Dialogs.xml
+++ b/colors/Light with Light Dialogs.xml
@@ -11,29 +11,29 @@
     <color name="Light2">b3dddddd</color>
     <color name="Light3">4ddddddd</color>
     <color name="Light4">1fdddddd</color>
-    
+
     <color name="Background">ffdddddd</color>
     <color name="FanartFade">2Fffffff</color>
     <color name="FloorFade">BBdddddd</color>
-    
+
     <color name="OSDBack">df000000</color>
     <color name="Panel">FF333333</color>
-    
+
     <color name="PanelWhite100">FFdddddd</color>
     <color name="PanelWhite70">B3dddddd</color>
     <color name="PanelWhite30">4Ddddddd</color>
     <color name="PanelWhite12">1Fdddddd</color>
     <color name="PanelBlack30">4D000000</color>
-    
+
     <color name="White100">FFdddddd</color>
     <color name="White70">B3dddddd</color>
     <color name="White30">4Ddddddd</color>
     <color name="White12">1Fdddddd</color>
-    
+
     <color name="Black100">FF000000</color>
     <color name="Black70">B3000000</color>
     <color name="Black30">4D000000</color>
     <color name="Black12">1F000000</color>
-    
-    
+
+
 </colors>

--- a/colors/defaults.xml
+++ b/colors/defaults.xml
@@ -11,29 +11,29 @@
     <color name="Light2">b3dddddd</color>
     <color name="Light3">4ddddddd</color>
     <color name="Light4">1fdddddd</color>
-    
+
     <color name="Background">ffdddddd</color>
     <color name="FanartFade">2Fffffff</color>
     <color name="FloorFade">BBdddddd</color>
-    
+
     <color name="OSDBack">df000000</color>
     <color name="Panel">FF333333</color>
-    
+
     <color name="PanelWhite100">FFdddddd</color>
     <color name="PanelWhite70">B3dddddd</color>
     <color name="PanelWhite30">4Ddddddd</color>
     <color name="PanelWhite12">1Fdddddd</color>
     <color name="PanelBlack30">4D000000</color>
-    
+
     <color name="White100">FFdddddd</color>
     <color name="White70">B3dddddd</color>
     <color name="White30">4Ddddddd</color>
     <color name="White12">1Fdddddd</color>
-    
+
     <color name="Black100">FF000000</color>
     <color name="Black70">B3000000</color>
     <color name="Black30">4D000000</color>
     <color name="Black12">1F000000</color>
-    
-    
+
+
 </colors>

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <overrides>
-    
+
     <!-- Weather Widget -->
     <widget label="31251" condition="!IsEmpty(Skin.String(weather.fanart.path))">Weather</widget>
 
     <!-- Playlist -->
     <widgetPlaylists>True</widgetPlaylists>
-    
+
     <!-- Additional Common Items -->
     <shortcut label="Hub 1119" type="Hub 1119" grouping="common" icon="special://skin/extras/icons/addon.png">ActivateWindow(1119)</shortcut>
     <shortcut label="Hub 1118" type="Hub 1118" grouping="common" icon="special://skin/extras/icons/addon.png">ActivateWindow(1118)</shortcut>
@@ -19,7 +19,7 @@
     <shortcut label="31192" type="MovieHub" grouping="common" icon="special://skin/extras/icons/film.png">ActivateWindow(1111)</shortcut>
     <shortcut label="31212" type="themoviedb.org episodes" grouping="common" icon="special://skin/extras/icons/director.png">ActivateWindow(1105)</shortcut>
     <shortcut label="31208" type="themoviedb.org movies" grouping="common" icon="special://skin/extras/icons/director.png">ActivateWindow(1104)</shortcut>
-    
+
     <!-- Override Actions Because Im A Dummy Who Doesnt Know The Correct Window IDs To Use -->
     <override action="ActivateWindow(3201)">
         <condition>true</condition>
@@ -37,14 +37,14 @@
         <condition>true</condition>
         <action>ActivateWindow(1105)</action>
     </override>
-    
+
     <!-- Browse for Backgrounds -->
     <backgroundBrowse>True</backgroundBrowse>
     <background label="::PLAYLIST::">playlistBackground</background>
-    
+
     <!-- Warning to Remove Settings -->
     <warn heading="31176" message="31177">ActivateWindow(Settings)</warn>
-    
+
     <!-- Icon Overrides -->
     <icon labelID="tvhub">special://skin/extras/icons/tv.png</icon>
     <icon labelID="moviehub">special://skin/extras/icons/film.png</icon>
@@ -123,7 +123,7 @@
     <icon image="DefaultAddonVideo.png">special://skin/extras/icons/video-addons.png</icon>
     <icon image="DefaultAddonMusic.png">special://skin/extras/icons/songs.png</icon>
     <icon image="DefaultAddonProgram.png">special://skin/extras/icons/addons.png</icon>
-    
+
     <!-- Thumbs -->
     <thumbnail label="3dtv.png">special://skin/extras/icons/3dtv.png</thumbnail>
     <thumbnail label="actor.png">special://skin/extras/icons/actor.png</thumbnail>
@@ -352,7 +352,7 @@
             <content>addon-video</content>
         </node>
         <content>video</content>
-        
+
     </video-groupings>
-    
+
 </overrides>

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -319,7 +319,7 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
                 <focusedlayout height="325" width="325" condition="StringCompare(Container(300).ListItem.Property(widgetaspect),Square)">
                     <control type="image">
@@ -363,7 +363,7 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
                 <focusedlayout height="325" width="562" condition="StringCompare(Container(300).ListItem.Property(widgetaspect),Thumbnail) | StringCompare(Container(300).ListItem.Property(widgetaspect),Fanart)">
                     <control type="image">
@@ -407,7 +407,7 @@
                             <effect type="fade" start="100" end="0" time="150" tween="sine" easing="out" />
                         </animation>
                     </control>
-                      
+
                 </focusedlayout>
                 <content limit="10" target="$SKINSHORTCUTS[target]">$SKINSHORTCUTS[content]</content>
             </control>

--- a/shortcuts/x1111.DATA.xml
+++ b/shortcuts/x1111.DATA.xml
@@ -18,7 +18,7 @@
         <action>ActivateWindow(Videos,special://skin/extras/playlists/RecentMovies.xsp,return)</action>
         <icon>special://skin/extras/icons/recent.png</icon>
     </shortcut>
-    
+
     <shortcut>
         <label>31175</label>
         <label2>Movie Hub Shortcut</label2>
@@ -31,7 +31,7 @@
         <action>RunScript(script.globalsearch,tvshows=true&amp;episodes=true&amp;movies=true)</action>
         <icon>special://skin/extras/icons/search.png</icon>
     </shortcut>
-    
+
     <shortcut>
         <label>135</label>
         <label2>Movie Hub Shortcut</label2>

--- a/shortcuts/x1112.DATA.xml
+++ b/shortcuts/x1112.DATA.xml
@@ -32,13 +32,13 @@
     </shortcut>
     <shortcut>
         <label2>Episode Hub Shortcut</label2>
-        <label>135</label>            
+        <label>135</label>
         <action>ActivateWindow(Videos,TvShowGenres,return)</action>
         <icon>special://skin/extras/icons/genre.png</icon>
     </shortcut>
     <shortcut>
         <label2>Episode Hub Shortcut</label2>
-        <label>20388</label>            
+        <label>20388</label>
         <action>ActivateWindow(Videos,TvShowStudios,return)</action>
         <icon>special://skin/extras/icons/director.png</icon>
     </shortcut>
@@ -50,7 +50,7 @@
     </shortcut>
     <shortcut>
         <label2>Episode Hub Shortcut</label2>
-        <label>652</label>            
+        <label>652</label>
         <action>ActivateWindow(Videos,TvShowYears,return)</action>
         <icon>special://skin/extras/icons/year.png</icon>
     </shortcut>


### PR DESCRIPTION
Lots of files had trailing whitespace. This cleans that up.

Done just using `sed -i 's/[ \t]*$//' *`.