### PR TITLE
Add support for Dolby Atmos and DTS:X detection from filename

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -3,6 +3,7 @@
 <includes>
 
     <include file="Defaults.xml" />
+	<include file="Variables.xml" />
 
     <!-- Views -->
     <include file="View_50_List.xml" />

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -339,7 +339,7 @@
                 <width>88</width>
                 <height>64</height>
                 <centertop>50%</centertop>
-                <texture colordiffuse="Dark1" fallback="flags/fallback.png">$INFO[ListItem.AudioCodec,flags/audio/,.png]</texture>
+                <texture colordiffuse="Dark1" fallback="flags/fallback.png">$VAR[ListItemAudioCodecPlusFilenameFlags,flags/audio/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagicons) + !IsEmpty(ListItem.AudioCodec)</visible>
             </control>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -60,7 +60,7 @@
                 <width>88</width>
                 <height>64</height>
                 <centertop>50%</centertop>
-                <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">$INFO[VideoPlayer.AudioCodec,flags/audio/,.png]</texture>
+                <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">$VAR[VideoPlayerAudioCodecPlusFilenameFlags,flags/audio/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
                 <visible>!IsEmpty(VideoPlayer.AudioCodec)</visible>
             </control>

--- a/1080i/Variables.xml
+++ b/1080i/Variables.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+	<includes>
+	<variable name="ListItemAudioCodecPlusFilenameFlags">
+		<value condition="String.Contains(ListItem.Filenameandpath,atmos)">atmos</value>
+		<value condition="String.Contains(ListItem.Filenameandpath,Atmos)">atmos</value>
+		<value condition="String.Contains(ListItem.Filenameandpath,ATMOS)">atmos</value>
+		<value condition="String.Contains(ListItem.Filenameandpath,dts-x)">dts-x</value>
+		<value condition="String.Contains(ListItem.Filenameandpath,DTS-X)">dts-x</value>
+		<value condition="String.Contains(ListItem.Filenameandpath,dtsx)">dts-x</value>
+		<value condition="String.Contains(ListItem.Filenameandpath,DTSX)">dts-x</value>
+		<value>$INFO[ListItem.AudioCodec]</value>
+	</variable>
+	<variable name="VideoPlayerAudioCodecPlusFilenameFlags">
+		<value condition="String.Contains(Player.Filenameandpath,atmos)">atmos</value>
+		<value condition="String.Contains(Player.Filenameandpath,Atmos)">atmos</value>
+		<value condition="String.Contains(Player.Filenameandpath,ATMOS)">atmos</value>
+		<value condition="String.Contains(Player.Filenameandpath,dts-x)">dts-x</value>
+		<value condition="String.Contains(Player.Filenameandpath,DTS-X)">dts-x</value>
+		<value condition="String.Contains(Player.Filenameandpath,dtsx)">dts-x</value>
+		<value condition="String.Contains(Player.Filenameandpath,DTSX)">dts-x</value>
+		<value>$INFO[VideoPlayer.AudioCodec]</value>
+	</variable>
+</includes>


### PR DESCRIPTION
Allow for showing of the Dolby Atmos and DTS:X flags based on the video having 'Atmos' or 'DTS-X' in the filename.

Based on work from this thread: https://forum.kodi.tv/showthread.php?tid=299685