### PR TITLE
Update version for xbmc.gui (Kodi 18 RC5.2 support)

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -5,7 +5,7 @@
     name="Arctic: Zephyr"
     provider-name="jurialmunkey">
     <requires>
-        <import addon="xbmc.gui" version="5.13.0"/>
+        <import addon="xbmc.gui" version="5.14.0"/>
         <import addon="script.skinshortcuts" version="0.4.0"/>
         <import addon="service.library.data.provider" version="0.1.0"/>
         <import addon="script.skin.helper.service" version="0.0.1"/>


### PR DESCRIPTION
Latest RC5.2 for Kodi 18 changed the ABI version, which needs to be
adjusted, to make Arctic Zephyer to load again.
See https://github.com/xbmc/xbmc/pull/14933 for more information.